### PR TITLE
#16 logging shows itself as the origin of the log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Feature: Add tooling: `code` - starts vscode in docker in brower
 
 - Fix: Change encoding date from `.iso8601` to `.deferredToDate` 
+- Fix: Show correct origin of log messages (#16)
 
 - Change: Scripting Provider `fetch` method uses AsnHTTPClient instead of FoundationNetwork's URLSession
 - Change: in `--fast` mode e2e-tests run in chromium

--- a/Sources/Server/Logging/Log.swift
+++ b/Sources/Server/Logging/Log.swift
@@ -94,11 +94,16 @@ struct Log {
     /// - Parameter
     ///     - msg: Accept multiline string
     ///     - request: Optional Request Object
-    static func debug(_ msg: String, request: Request? = nil /* , file: String = #fileID, function: String = #function, line: UInt = #line */) {
+    static func debug(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.debug(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
-                //file: file, function: function, line: line
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 
@@ -107,10 +112,16 @@ struct Log {
     /// - Parameter
     ///     - msg: Accept multiline string
     ///     - request: Optional Request Object
-    static func info(_ msg: String, request: Request? = nil) {
+    static func info(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.info(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 
@@ -119,10 +130,16 @@ struct Log {
     /// - Parameter
     ///     - msg: Accept multiline string
     ///     - request: Optional Request Object
-    static func notice(_ msg: String, request: Request? = nil) {
+    static func notice(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.notice(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 
@@ -131,10 +148,16 @@ struct Log {
     /// - Parameter
     ///      - msg: Accept multiline string
     ///      - request: Optional Request Object
-    static func warning(_ msg: String, request: Request? = nil) {
+    static func warning(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.warning(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 
@@ -143,10 +166,16 @@ struct Log {
     /// - Parameter
     ///      - msg: Accept multiline string
     ///      - request: Optional Request Object
-    static func error(_ msg: String, request: Request? = nil) {
+    static func error(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.error(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 
@@ -154,10 +183,16 @@ struct Log {
     ///
     /// - Parameter msg: Accept multiline string
     ///      - request: Optional Request Object
-    static func critical(_ msg: String, request: Request? = nil) {
+    static func critical(
+        _ msg: String,
+        request: Request? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line) {
         Log.logger.critical(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
-                metadata: enrichMetadata(with: request)
+                metadata: enrichMetadata(with: request),
+                file: file, function: function, line: line
         )
     }
 

--- a/Sources/Server/Logging/Log.swift
+++ b/Sources/Server/Logging/Log.swift
@@ -94,10 +94,11 @@ struct Log {
     /// - Parameter
     ///     - msg: Accept multiline string
     ///     - request: Optional Request Object
-    static func debug(_ msg: String, request: Request? = nil) {
+    static func debug(_ msg: String, request: Request? = nil /* , file: String = #fileID, function: String = #function, line: UInt = #line */) {
         Log.logger.debug(
                 .init(stringLiteral: msg.replacingOccurrences(of: "\n", with: " ")),
                 metadata: enrichMetadata(with: request)
+                //file: file, function: function, line: line
         )
     }
 

--- a/Sources/Server/Logging/LogWriter.swift
+++ b/Sources/Server/Logging/LogWriter.swift
@@ -160,7 +160,7 @@ public struct LogWriter: LogHandler {
             var debugLog = ""
             if Constants.isRelease == false {
                 debugLog = " | \(logMessage.function ?? "")"
-                        + "in \(logMessage.file ?? ""):\(String(logMessage.line ?? 0))"
+                        + " in \(logMessage.file ?? ""):\(String(logMessage.line ?? 0))"
             }
             print("\(printLevel)\(logMessage.date.rfc1123): \(logMessage.message)\(printMetadata)\(debugLog)")
         }

--- a/Tests/ServerTests/Logging/LoggingDebugFunctionsTest.swift
+++ b/Tests/ServerTests/Logging/LoggingDebugFunctionsTest.swift
@@ -8,10 +8,57 @@ final class LoggingDebugFunctionsTest: XCTestCase {
         Log.main = Log(level: Logger.Level.trace)
     }
 
-    func testLogFromThisFunction() {
-        Log.debug("Log from testLogFromThisFunction")
-        XCTAssertEqual(LogWriter.lastLog?.message, "Log from testLogFromThisFunction")
+    func testDebugLogFromThisFunction() {
+        Log.debug("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
         XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "debug")
+        XCTAssertEqual("testDebugLogFromThisFunction()", #function)
+
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+
+    func testInfoLogFromThisFunction() {
+        Log.info("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "info")
+        XCTAssertEqual("testInfoLogFromThisFunction()", #function)
+
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+
+    func testNoticeLogFromThisFunction() {
+        Log.notice("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "notice")
+        XCTAssertEqual("testNoticeLogFromThisFunction()", #function)
+
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+
+    func testWarningLogFromThisFunction() {
+        Log.warning("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "warning")
+        XCTAssertEqual("testWarningLogFromThisFunction()", #function)
+
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+
+    func testErrorLogFromThisFunction() {
+        Log.error("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "error")
+        XCTAssertEqual("testErrorLogFromThisFunction()", #function)
+
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+
+    func testCriticalLogFromThisFunction() {
+        Log.critical("Test log entry")
+        XCTAssertContains(LogWriter.lastLog?.message, "log")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "critical")
+        XCTAssertEqual("testCriticalLogFromThisFunction()", #function)
+
         XCTAssertContains(LogWriter.lastLog?.function, #function)
     }
 }

--- a/Tests/ServerTests/Logging/LoggingDebugFunctionsTest.swift
+++ b/Tests/ServerTests/Logging/LoggingDebugFunctionsTest.swift
@@ -1,0 +1,17 @@
+import Foundation
+@testable import Server
+import XCTVapor
+
+final class LoggingDebugFunctionsTest: XCTestCase {
+
+    override func setUp() {
+        Log.main = Log(level: Logger.Level.trace)
+    }
+
+    func testLogFromThisFunction() {
+        Log.debug("Log from testLogFromThisFunction")
+        XCTAssertEqual(LogWriter.lastLog?.message, "Log from testLogFromThisFunction")
+        XCTAssertEqual(LogWriter.lastLog?.level.lowercased(), "debug")
+        XCTAssertContains(LogWriter.lastLog?.function, #function)
+    }
+}


### PR DESCRIPTION
Implement tests (`LoggingDebugFunctionsTest`)  and implementation to show the origin of the log message. 
Proxy #fileID,  #function and #line to Logging-System.

Fixed missing whitespace in log writers output: 
`testWarningLogFromThisFunction() in ServerTests/LoggingDebugFunctionsTest.swift:39`

Updated Changelog. 