### PR TITLE
rename redis to uitsmijter-session

### DIFF
--- a/.github/workflows/pull_request_opend.yaml
+++ b/.github/workflows/pull_request_opend.yaml
@@ -14,6 +14,6 @@ jobs:
       repository-projects: read
 
     if: always()
-    uses: uitsmijter/workflows/.github/workflows/pullrequest-mattermost.yaml@main
+    uses: uitsmijter/workflows/.github/workflows/pullrequest-mattermost.yaml@v1.0.5
     secrets:
       WEBHOOK: ${{ secrets.MATTERMOST_WEBHOOK_BUILD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Feature: Add tooling: `remove` - to clear out all docker resources and clean up build folder
 - Feature: Add tooling: `code` - starts vscode in docker in brower
+- Feature: Add support for local namespace scoped tennants and clients
 
 - Fix: Change encoding date from `.iso8601` to `.deferredToDate` 
 - Fix: Show correct origin of log messages (#16)
@@ -9,6 +10,7 @@
 - Change: Scripting Provider `fetch` method uses AsnHTTPClient instead of FoundationNetwork's URLSession
 - Change: in `--fast` mode e2e-tests run in chromium
 - Change: Removed webp support for Uitsmijter default login page
+- Change: name of the redis database to uitsmijter-session-master and uitsmijter-session-slave
 
 - Update: to Swift 5.9.2
 - Update buildbox to 2.3.0

--- a/Deployment/docker-compose.yml
+++ b/Deployment/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 
 x-shared_environment: &shared_environment
   LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/Deployment/helm/uitsmijter/templates/deployment.yaml
+++ b/Deployment/helm/uitsmijter/templates/deployment.yaml
@@ -44,12 +44,14 @@ spec:
                 name: jwt-secret
 
           env:
+            - name: UITSMIJTER_NAMESPACE
+              value: {{ include "uitsmijter.namespace" . }}
             - name: REDIS_HOST
-              value: "redis-master"
+              value: "uitsmijter-sessions-master"
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: redis
+                  name: uitsmijter-sessions
                   key: 'redis-password'
 
 

--- a/Deployment/helm/uitsmijter/templates/redis.yaml
+++ b/Deployment/helm/uitsmijter/templates/redis.yaml
@@ -1,26 +1,24 @@
 ---
-# Source: redis/templates/secret.yaml
 apiVersion: v1
 kind: Secret
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis
+  name: uitsmijter-sessions
   labels:
-    app: redis
+    app: uitsmijter-sessions
 type: Opaque
 data:
   redis-password: {{ .Values.redisPassword | default (randAlphaNum 12) | b64enc | quote }}
 
 
 ---
-# Source: redis/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis
+  name: uitsmijter-sessions
   labels:
-    app: redis
+    app: uitsmijter-sessions
 data:
   redis.conf: |-
     # User-supplied configuration:
@@ -39,14 +37,13 @@ data:
     rename-command FLUSHALL ""
 
 ---
-# Source: redis/templates/health-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-health
+  name: uitsmijter-sessions-health
   labels:
-    app: redis
+    app: uitsmijter-sessions
 data:
   ping_readiness_local.sh: |-
     #!/bin/bash
@@ -122,14 +119,13 @@ data:
     exit $exit_status
 
 ---
-# Source: redis/templates/headless-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-headless
+  name: uitsmijter-sessions-headless
   labels:
-    app: redis
+    app: uitsmijter-sessions
 spec:
   type: ClusterIP
   clusterIP: None
@@ -138,17 +134,16 @@ spec:
       port: 6379
       targetPort: redis
   selector:
-    app: redis
+    app: uitsmijter-sessions
 
 ---
-# Source: redis/templates/redis-master-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-master
+  name: uitsmijter-sessions-master
   labels:
-    app: redis
+    app: uitsmijter-sessions
 spec:
   type: ClusterIP
   ports:
@@ -156,18 +151,17 @@ spec:
       port: 6379
       targetPort: redis
   selector:
-    app: redis
+    app: uitsmijter-sessions
     role: master
 
 ---
-# Source: redis/templates/redis-slave-svc.yaml
 apiVersion: v1
 kind: Service
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-slave
+  name: uitsmijter-sessions-slave
   labels:
-    app: redis
+    app: uitsmijter-sessions
 spec:
   type: ClusterIP
   ports:
@@ -175,28 +169,27 @@ spec:
       port: 6379
       targetPort: redis
   selector:
-    app: redis
+    app: uitsmijter-sessions
     role: slave
 
 ---
-# Source: redis/templates/redis-master-statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-master
+  name: uitsmijter-sessions-master
   labels:
-    app: redis
+    app: uitsmijter-sessions
 spec:
   selector:
     matchLabels:
-      app: redis
+      app: uitsmijter-sessions
       role: master
-  serviceName: redis-headless
+  serviceName: uitsmijter-sessions-headless
   template:
     metadata:
       labels:
-        app: redis
+        app: uitsmijter-sessions
         role: master
       annotations:
         checksum/health: caabbb72e0c57d8fc605a29541deb6b7dc0aa883227a9d292183ef16103a36e7
@@ -239,7 +232,7 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: redis
+                  name: uitsmijter-sessions
                   key: redis-password
             - name: REDIS_PORT
               value: "6379"
@@ -273,7 +266,7 @@ spec:
           volumeMounts:
             - name: health
               mountPath: /health
-            - name: redis-data
+            - name: uitsmijter-sessions-data
               mountPath: /data
               subPath:
             - name: config
@@ -283,18 +276,18 @@ spec:
       volumes:
         - name: health
           configMap:
-            name: redis-health
+            name: uitsmijter-sessions-health
             defaultMode: 0755
         - name: config
           configMap:
-            name: redis
+            name: uitsmijter-sessions
         - name: redis-tmp-conf
           emptyDir: { }
   volumeClaimTemplates:
     - metadata:
-        name: redis-data
+        name: uitsmijter-sessions-data
         labels:
-          app: redis
+          app: uitsmijter-sessions
           component: master
       spec:
         storageClassName: {{ .Values.storageClassName | quote }}
@@ -309,25 +302,24 @@ spec:
     type: RollingUpdate
 
 ---
-# Source: redis/templates/redis-slave-statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   namespace: {{ include "uitsmijter.namespace" . }}
-  name: redis-slave
+  name: uitsmijter-sessions-slave
   labels:
-    app: redis
+    app: uitsmijter-sessions
 spec:
   replicas: 1
-  serviceName: redis-headless
+  serviceName: uitsmijter-sessions-headless
   selector:
     matchLabels:
-      app: redis
+      app: uitsmijter-sessions
       role: slave
   template:
     metadata:
       labels:
-        app: redis
+        app: uitsmijter-sessions
         role: slave
       annotations:
         checksum/health: caabbb72e0c57d8fc605a29541deb6b7dc0aa883227a9d292183ef16103a36e7
@@ -373,7 +365,7 @@ spec:
             - name: REDIS_REPLICATION_MODE
               value: slave
             - name: REDIS_MASTER_HOST
-              value: redis-master-0.redis-headless
+              value: uitsmijter-sessions-master-0.uitsmijter-sessions-headless
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_MASTER_PORT_NUMBER
@@ -381,12 +373,12 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: redis
+                  name: uitsmijter-sessions
                   key: redis-password
             - name: REDIS_MASTER_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: redis
+                  name: uitsmijter-sessions
                   key: redis-password
           ports:
             - name: redis
@@ -418,7 +410,7 @@ spec:
           volumeMounts:
             - name: health
               mountPath: /health
-            - name: redis-data
+            - name: uitsmijter-sessions-data
               mountPath: /data
             - name: config
               mountPath: /opt/bitnami/redis/mounted-etc
@@ -427,20 +419,20 @@ spec:
       volumes:
         - name: health
           configMap:
-            name: redis-health
+            name: uitsmijter-sessions-health
             defaultMode: 0755
         - name: config
           configMap:
-            name: redis
+            name: uitsmijter-sessions
         - name: sentinel-tmp-conf
           emptyDir: { }
         - name: redis-tmp-conf
           emptyDir: { }
   volumeClaimTemplates:
     - metadata:
-        name: redis-data
+        name: uitsmijter-sessions-data
         labels:
-          app: redis
+          app: uitsmijter-sessions
           component: slave
       spec:
         storageClassName: {{ .Values.storageClassName | quote }}

--- a/Deployment/helm/uitsmijter/templates/uitsmijter-config.yaml
+++ b/Deployment/helm/uitsmijter/templates/uitsmijter-config.yaml
@@ -10,5 +10,6 @@ data:
   COOKIE_EXPIRATION_IN_DAYS: {{ .Values.config.cookieExpirationInDays | default 7 | quote }}
   TOKEN_EXPIRATION_IN_HOURS: {{ .Values.config.tokenExpirationInHours | default 2 | quote }}
   TOKEN_REFRESH_EXPIRATION_IN_HOURS: {{ .Values.config.tokenRefreshExpirationInHours | default 720 | quote }}
-  SUPPORT_KUBERNETES_CRD: "true"
+  SUPPORT_KUBERNETES_CRD: {{ .Values.config.crd.enabled | default "true" | quote }}
+  SCOPED_KUBERNETES_CRD: {{ .Values.config.crd.scoped | default "false" | quote }}
   DISPLAY_VERSION: {{ if hasKey .Values.config "displayVersion" }}{{ .Values.config.displayVersion | quote }}{{ else }}"true"{{ end }}

--- a/Deployment/helm/uitsmijter/values.yaml
+++ b/Deployment/helm/uitsmijter/values.yaml
@@ -25,6 +25,10 @@ config:
   # show the version information at /versions
   displayVersion: true
 
+  crd:
+    enabled: true
+    scoped: false
+
 domains:
   - domain: "nightly.uitsmijter.io"
     tlsSecretName: "nightly.uitsmijter.io"

--- a/Deployment/tooling/includes/build.fns.sh
+++ b/Deployment/tooling/includes/build.fns.sh
@@ -5,7 +5,7 @@
 # Resize and reformat images
 function buildImages() {
   h2 "Resize and reformat images"
-  docker-compose \
+  docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${PROJECT_DIR}/.env" \
     up \
@@ -19,7 +19,7 @@ function buildIncrementalBinary() {
   buildImages
   h2 "Build a binary incremental"
   local dockerComposeBuildParameter=${1}
-  RUNTIME_IMAGE="" docker-compose \
+  RUNTIME_IMAGE="" docker compose \
       -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
       --env-file "${PROJECT_DIR}/.env" \
       run --rm \
@@ -93,7 +93,7 @@ function buildHelm() {
 function buildRuntime() {
   h2 "Build uitsmijter runtime"
   local TAG=${1:-${TAG}}
-  RUNTIME_IMAGE=${TAG} docker-compose \
+  RUNTIME_IMAGE=${TAG} docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${SCRIPT_DIR}/.env" \
     build \

--- a/Deployment/tooling/includes/code.fns.sh
+++ b/Deployment/tooling/includes/code.fns.sh
@@ -5,7 +5,7 @@
 # Open a code edior
 function openCode() {
   h2 "Open project in code"
-  docker-compose \
+  docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${PROJECT_DIR}/.env" \
     up \
@@ -25,7 +25,7 @@ function openCode() {
   echo ""
   echo "Press enter to stop the code-server."
   read -r
-  docker-compose -f "${SCRIPT_DIR}/Deployment/docker-compose.yml" down code
+  docker compose -f "${SCRIPT_DIR}/Deployment/docker-compose.yml" down code
 
 
 }

--- a/Deployment/tooling/includes/kind.fns.sh
+++ b/Deployment/tooling/includes/kind.fns.sh
@@ -47,7 +47,7 @@ function kindStartCluster() {
     --set image.repository="${IMAGE%%:*}" \
     --set image.tag="${IMAGE##*:}"
 
-  kindWaitForPods uitsmijter app=redis,role=master app=uitsmijter
+  kindWaitForPods uitsmijter app=uitsmijter-sessions,role=master app=uitsmijter
 
   kubectl apply \
     -f "${PROJECT_DIR}/Deployment/e2e/uitsmijter-tenant.yaml" \

--- a/Deployment/tooling/includes/run.fns.sh
+++ b/Deployment/tooling/includes/run.fns.sh
@@ -5,7 +5,7 @@
 # Run incremental build in docker environment
 function runInDocker() {
   h2 "Run incremental build in a docker environment"
-  RUNTIME_IMAGE="${IMAGENAME}-runtime:latest" docker-compose \
+  RUNTIME_IMAGE="${IMAGENAME}-runtime:latest" docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${SCRIPT_DIR}/.env" \
     up \

--- a/Deployment/tooling/includes/test.fns.sh
+++ b/Deployment/tooling/includes/test.fns.sh
@@ -8,7 +8,7 @@ include "test.var.sh"
 function unitTests() {
   h2 "Run all UnitTests"
   local dockerComposeBuildParameter=${1}
-  docker-compose \
+  docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${PROJECT_DIR}/.env" \
     up \
@@ -32,7 +32,7 @@ function e2eTests(){
   echo "Running tests:"
 
   status=0
-  ARGUMENTS="${ARGUMENTS}" GITHUB_ACTION=${GITHUB_ACTION} docker-compose \
+  ARGUMENTS="${ARGUMENTS}" GITHUB_ACTION=${GITHUB_ACTION} docker compose \
     -f "${PROJECT_DIR}/Deployment/docker-compose.yml" \
     --env-file "${PROJECT_DIR}/.env" \
     up \

--- a/Sources/Server/Constants.swift
+++ b/Sources/Server/Constants.swift
@@ -54,6 +54,8 @@ struct Constants {
     /// Runtime settings
     struct RUNTIME {
         static let SUPPORT_KUBERNETES_CRD: Bool = Bool(Environment.get("SUPPORT_KUBERNETES_CRD") ?? "false") ?? false
+        static let SCOPED_KUBERNETES_CRD: Bool = Bool(Environment.get("SCOPED_KUBERNETES_CRD") ?? "false") ?? false
+        static let UITSMIJTER_NAMESPACE: String = Environment.get("UITSMIJTER_NAMESPACE") ?? ""
     }
 
     // Security


### PR DESCRIPTION
you can restrict the tenants and clients to load with
```
  crd:
    enabled: true
    scoped: false
```

The redis for saving the user session is now renamed from `redis` to `uitsmijter-session` to be installed in the overloaded namespaces. 

Switched from `docker-compose` to `docker compose`