### PR TITLE
Fix OpenID Discovery endpoint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # 0.10.0
-- prerelease
 - Feature: **OpenID Connect Discovery 1.0** endpoint at `/.well-known/openid-configuration` with full multi-tenant support, allowing clients to automatically discover provider capabilities and endpoints
 - Feature: **E2E Test Filtering** - New `--filter` flag for `./tooling.sh e2e` command allows selective test execution for faster development cycles
 - Feature: Enhanced **Kubernetes API** with automatic retry logic for improved reliability when loading tenant and client configurations from CRDs
 - Feature: Improved **Helm Chart** with default resource limits helper for easier production deployments
 
+- Fix: **OpenID Discovery endpoint** now includes `end_session_endpoint` field pointing to `/logout` for RP-initiated logout support
+- Fix: **JSON output formatting** - URLs in `.well-known/openid-configuration` no longer have escaped forward slashes for better compatibility with strict parsers
 - Fix: **Redis connection stability** - Connection pool no longer blocks startup, graceful handling of DNS resolution failures, and improved timeout configuration
 - Fix: **S3 template loading** race condition in multi-tenant environments
 - Fix: **PKCE validation** order in OAuth2 authorization flow

--- a/Sources/Uitsmijter-AuthServer/Controllers/WellKnownController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/WellKnownController.swift
@@ -128,7 +128,7 @@ struct WellKnownController: RouteCollection {
 
         // Encode the configuration to JSON
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
 
         guard let jsonData = try? encoder.encode(configuration),
               let jsonString = String(data: jsonData, encoding: .utf8) else {

--- a/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfiguration.swift
+++ b/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfiguration.swift
@@ -73,6 +73,17 @@ struct OpenidConfiguration: Codable, Sendable {
     /// ```
     let jwks_uri: String
 
+    /// OPTIONAL. URL at the OP to which an RP can perform a redirect to request that the End-User be logged out.
+    ///
+    /// This endpoint is used for RP-initiated logout as specified in OpenID Connect Session Management.
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// "https://auth.example.com/logout"
+    /// ```
+    let end_session_endpoint: String?
+
     /// REQUIRED. JSON array containing a list of the OAuth 2.0 response_type values that this OP supports.
     ///
     /// Dynamic OpenID Providers MUST support the `code`, `id_token`, and `token id_token` response types.
@@ -400,6 +411,7 @@ struct OpenidConfiguration: Codable, Sendable {
     ///   - authorization_endpoint: REQUIRED. Authorization endpoint URL
     ///   - token_endpoint: Token endpoint URL (required unless only using Implicit Flow)
     ///   - jwks_uri: REQUIRED. JWK Set document URL
+    ///   - end_session_endpoint: OPTIONAL. End session (logout) endpoint URL
     ///   - response_types_supported: REQUIRED. Supported response types
     ///   - subject_types_supported: REQUIRED. Supported subject identifier types
     ///   - id_token_signing_alg_values_supported: REQUIRED. Supported ID Token signing algorithms
@@ -438,6 +450,7 @@ struct OpenidConfiguration: Codable, Sendable {
         authorization_endpoint: String,
         token_endpoint: String?,
         jwks_uri: String,
+        end_session_endpoint: String? = nil,
         response_types_supported: [String],
         subject_types_supported: [String],
         id_token_signing_alg_values_supported: [String],
@@ -476,6 +489,7 @@ struct OpenidConfiguration: Codable, Sendable {
         self.authorization_endpoint = authorization_endpoint
         self.token_endpoint = token_endpoint
         self.jwks_uri = jwks_uri
+        self.end_session_endpoint = end_session_endpoint
         self.response_types_supported = response_types_supported
         self.subject_types_supported = subject_types_supported
         self.id_token_signing_alg_values_supported = id_token_signing_alg_values_supported

--- a/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfigurationBuilder.swift
+++ b/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfigurationBuilder.swift
@@ -170,6 +170,7 @@ actor OpenidConfigurationBuilder {
         let tokenEndpoint = "\(issuer)/token"
         let jwksUri = "\(issuer)/.well-known/jwks.json"
         let userinfoEndpoint = "\(issuer)/token/info"
+        let endSessionEndpoint = "\(issuer)/logout"
 
         // Get policy URLs from tenant information
         let policyUri = tenant.config.informations?.privacy_url
@@ -180,6 +181,7 @@ actor OpenidConfigurationBuilder {
             authorization_endpoint: authorizationEndpoint,
             token_endpoint: tokenEndpoint,
             jwks_uri: jwksUri,
+            end_session_endpoint: endSessionEndpoint,
             response_types_supported: Self.defaultResponseTypes,
             subject_types_supported: Self.defaultSubjectTypes,
             id_token_signing_alg_values_supported: Self.defaultIdTokenSigningAlgorithms,

--- a/Tests/Uitsmijter-AuthServerTests/WellKnown/OpenidConfigurationBuilderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/WellKnown/OpenidConfigurationBuilderTest.swift
@@ -379,6 +379,23 @@ struct OpenidConfigurationBuilderTest {
         #expect(config.claims_supported?.contains("tenant") == true)
     }
 
+    @Test("Builder includes end session endpoint")
+    func builderIncludesEndSessionEndpoint() async throws {
+        let app = try await createTestApp()
+        defer { Task { try? await app.asyncShutdown() } }
+
+        let tenant = createTestTenant(name: "LogoutTenant", hosts: ["logout.example.com"])
+        app.entityStorage.tenants.insert(tenant)
+
+        let builder = OpenidConfigurationBuilder()
+        let request = createMockRequest(app: app, host: "logout.example.com")
+
+        let config = await builder.build(for: tenant, request: request, storage: app.entityStorage)
+
+        let expectedEndSessionEndpoint = "https://logout.example.com/logout"
+        #expect(config.end_session_endpoint == expectedEndSessionEndpoint)
+    }
+
     // MARK: - Deduplication Tests
 
     @Test("Builder deduplicates scopes from multiple clients")


### PR DESCRIPTION
- Add missing end_session_endpoint field to OpenID configuration pointing to /logout endpoint for RP-initiated logout support
- Fix escaped forward slashes in JSON output by adding .withoutEscapingSlashes to JSONEncoder for better parser compatibility
- Add test coverage for end_session_endpoint