### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -58,6 +58,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: read
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache    


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/22](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/22)

To fix the problem, we should explicitly declare a `permissions` block for the `e2etest` job. According to both the flagged recommendation and GitHub's security guidance, this should typically be set to `contents: read` unless the job needs higher privileges. In this workflow, other jobs only allow higher permissions where publishing/deployment is needed, so the e2etest job should be given only read access to the repository contents. This is implemented by adding a `permissions:` stanza directly under the job configuration for `e2etest`. Lines before and after the affected region should remain unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
