### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/19](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/19)

The best way to fix this issue is to ensure that every job in the workflow, or at the workflow level itself, sets explicit and minimal permissions for the GITHUB_TOKEN. Since the minimal required permission for most build jobs is simply to read repository content, we can add `permissions: contents: read` either at the workflow level (near the top), or—if more specific, at the job level for the `build` job. The least intrusive, most scalable fix is to place `permissions: contents: read` at the root of the YAML workflow (just after the `name:` and before `env:`) so all jobs except those with their own `permissions:` block inherit this minimal setup. This avoids redundancy and ensures that only jobs that truly need more permissions (like `build-helm`) can override it.

No extra methods, imports, or external definitions are needed—just the addition of a single explicit `permissions:` block with the appropriate scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
