### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -28,6 +28,8 @@ jobs:
   unittest:
     name: Run UnitTest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/16](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/16)

To fix the problem, we should add an explicit `permissions` block to the `unittest` job definition in `.github/workflows/release-candidate.yaml`, just as is done for `e2etest` and `build-helm`. For a typical unittest workflow, the minimal required privilege is usually `contents: read`, allowing the job to read repository files for testing, but restricting any write operations. To implement the fix, locate the `unittest` job definition block (beginning at line 28) and insert a `permissions` section before steps, with `contents: read`.
No new dependencies or further code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
