### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/feature.yaml
+++ b/.github/workflows/feature.yaml
@@ -1,4 +1,6 @@
 name: Feature
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/1](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with the minimum required privileges to either the root of the workflow or to individual jobs. The steps for `lint`, `unittest`, `build`, and `e2etest` only need to read from the repository; they do not need to write to it. Therefore, set `permissions: contents: read` for those jobs. For DRYness and stronger guarantees, it's best to set `permissions: contents: read` at the workflow level (i.e., at the very top, directly beneath `name`), so all jobs inherit it unless they have their own `permissions` block (as done already for the two `notify` jobs). This reduces the risk of new jobs missing the block in the future.

You only need to modify the YAML at the workflow's root (just under `name: Feature`), adding:

```yaml
permissions:
  contents: read
```

No other changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
