### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -40,6 +40,8 @@ jobs:
     needs:
       - lint
       - unittest
+    permissions:
+      contents: read
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache    


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/21](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/21)

To fix the problem, you should add a `permissions` block to the `build` job restricting its GITHUB_TOKEN privilege to the least required—in this case, `contents: read`. This follows the workflow's established pattern, is recommended by CodeQL, and will ensure the job does not implicitly inherit overly permissive access. The change should be made in-place for the `build` job in `.github/workflows/release-candidate.yaml`, best placed immediately after the `needs:` block (so typically after line 42). No code or functional changes besides augmenting the job’s security context will be made.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
