### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,6 +57,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    permissions:
+      contents: read
     steps:
       - name: Delete huge unnecessary tools folder
         run: rm -rf /opt/hostedtoolcache    


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/20](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/20)

To fix this problem, we should add an explicit `permissions` key at the top level of the `e2etest` job, restricting its access to the minimal necessary privileges. By default, this should be `permissions: contents: read` unless the job requires more (which is not apparent here). This follows the principle of least privilege and aligns the `e2etest` job with the other jobs in the workflow that correctly limit their permissions. The change should be made by inserting a `permissions:` block at the same indentation level as `runs-on` and `needs` for the job, just before the `steps:` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
