### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
 env:
   STORE_ARTEFACTS: true
   RUN_LINTER: true


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/18](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/18)

To fix the issue, set an explicit minimal `permissions` block at the workflow level, just beneath the `name:` (and `on:`) block in `.github/workflows/release.yaml`. This ensures all jobs default to least privilege (e.g., `contents: read`), except where overridden (as in `build-helm`). No changes to job logic or steps are required; this action simply controls the GITHUB_TOKEN permissions. 

Specifically:
- Insert the following after the `name:` and `on:` section, before `env:`:  
  ```yaml
  permissions:
    contents: read
  ```
  This ensures all jobs default to read-only access to repository content unless otherwise specified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
