### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
   # Lint
   lint:
     name: Run Linter checks
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/17](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/17)

To resolve the CodeQL warning and adhere to the principle of least privilege, add an explicit `permissions` block to the `lint` job that grants only those permissions necessary for linting. The linter only needs read access to the codebase (`contents: read`), so no write or other extended permissions are required. 

Edit the workflow file `.github/workflows/release.yaml` by inserting  
```yaml
permissions:
  contents: read
```
immediately after `name: Run Linter checks` (line 19), before `runs-on:` (line 20).  
If more jobs in the file are similar and lack a `permissions` block, a similar addition is recommended, but per the question, the concrete fix should address only the `lint` job as flagged.

No new methods, imports, or variable definitions are required since this change only involves a YAML configuration update.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
