### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -1,4 +1,6 @@
 name: Release Candidate
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/15](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/15)

To fix this issue, we should add a `permissions` block to the workflow, either globally at the top level (which will apply to all jobs unless overridden), or to each individual job missing one. The minimal starting point recommended by CodeQL is `contents: read`, which suffices for common read-only operations like checking out the repository. The best-practice is to set the global permissions unless there are differing requirements per job, and then override as needed for jobs requiring additional permissions. In this case, we will add a root-level `permissions` block with `contents: read` immediately beneath `name: Release Candidate` (line 1)—this will apply the restriction to all jobs except those that already specify their own permissions. This approach minimizes required edits and maintains existing job-specific overrides.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
