### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -75,6 +75,8 @@ jobs:
   e2etest:
     name: Run E2E-Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - build
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/14](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/14)

To fix the problem, we should explicitly set the minimal required permissions for the `e2etest` job inside `.github/workflows/nightly.yaml`. The best practice is to use the least privilege required: for jobs that only need to read code (checkout the repository, run tests, etc.), setting `permissions: { contents: read }` suffices. This matches the style used in the `notify_mattermost` and `notify_mastodon` jobs. The change should be introduced immediately after the `runs-on` key (before or after `needs`), but most commonly immediately after `runs-on` for readability and consistency. No additional dependencies or imports are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
