### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -49,6 +49,8 @@ jobs:
 
   e2etest:
     name: Run E2E-Tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
       - build


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/13](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/13)

To fix this problem, we need to explicitly set a `permissions` block for the `e2etest` job. This restricts the permissions of the `GITHUB_TOKEN` available to the job. The minimal safe permissions that almost all jobs need is `contents: read`, which allows Actions to checkout code but not mutate or write to the repo. As the job just runs tests and builds using checked-out code, there's no evidence it needs more elevated permissions. Place this block inside the `e2etest:` job definition, at the same indentation level as `name`, `runs-on`, and `needs`. No new imports or external definitions are required; just a new permissions block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
