### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -36,6 +36,8 @@ jobs:
   build:
     name: Build Uitsmijter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs:
       - lint
       - unittest


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/12](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/12)

To resolve the issue, the `build` job should be given an explicit `permissions` block that restricts its permissions to the minimum necessary. Because it only checks out source code and builds artifacts, `contents: read` is generally appropriate. This block should be added under the `build:` job. No changes to step logic are required—just the addition of the permissions. No new imports or dependencies are needed, as this is a YAML configuration change specific to GitHub Actions.

Specifically, insert the following YAML block under `build:` and before `needs:`:
```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
