### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -53,6 +53,8 @@ jobs:
   # Build Binary
   build:
     name: Build Uitsmijter
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
       - lint


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/10](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/10)

To fix the problem, explicitly specify the permissions required for the `build` job in the `.github/workflows/nightly.yaml` workflow. The likely minimal requirement for artifact-building steps is `contents: read`, unless an action (for example, an upload step) needs more. But from the given snippet, no such actions are in use for this job. The fix is to add a `permissions:` block with `contents: read` under the `build` job (directly underneath `name: Build Uitsmijter` and before or after `runs-on:`), following the style of the `publish` job. No other code or imports are required — just a single YAML addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
