### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -30,6 +30,8 @@ jobs:
   # Lint
   lint:
     name: Run Linter checks
+    permissions:
+      contents: read
     needs:
       - cleancache
     runs-on: ubuntu-latest
@@ -38,7 +40,6 @@ jobs:
         uses: actions/checkout@v5
       - uses: ./.github/actions/step-lint
         if: ${{ env.RUN_LINTER != 'false' }}
-
   unittest:
     name: Run UnitTest
     needs:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/7](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/7)

To fix the issue, add a `permissions` block to the `lint` job (lines 31–41) with the least required privileges. For linting, typically only read access to repository contents (`contents: read`) is required. The block should be placed inside the `lint` job definition, at the same level as `name`, `needs`, `runs-on`, and `steps`, directly after `name: Run Linter checks` or before `needs`. No changes to other jobs are necessary since they already specify their own permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
