### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   STORE_ARTEFACTS: true
   RUN_LINTER: true


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/3](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/3)

The best way to fix this problem is to explicitly specify a `permissions` block with `contents: read` at the root of the workflow or in each job that doesn't already restrict permissions. This ensures that all jobs in the workflow only have read access to repository contents, unless more privilege is explicitly required (as done in the notification jobs shown in the snippet). This change should be made at the top level of `.github/workflows/nightly.yaml`, right after the `name:` or `on:` block, to apply to all jobs except those that already have their own restrictive `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
