### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,4 +1,6 @@
 name: Issues
+permissions:
+  contents: read
 on:
   issues:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/4](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/4)

The best fix is to define a `permissions` block at the job or root level of the workflow to explicitly restrict the GITHUB_TOKEN's privileges to only what is necessary. Since the workflow handles issues and issue comments and posts outbound notifications via a webhook, it likely does not need write access to contents or administrative privileges but may need (at most) read-only access to repository content and (potentially) write access to issues if any action is performed on issues via GitHub's API. However, given the provided code only posts to Mattermost and does not seem to perform any mutation on GitHub, it's safest to start with minimal permissions. The commonly accepted minimal starting block is:

```yaml
permissions:
  contents: read
```

This block should be added at the workflow root, above `on:`, or at the job level (inside `Notify:` but above `uses:`). If the job or called reusable workflow needs more (for example, write access to issues), permissions can be expanded accordingly. Since we're instructed to start with a minimal block, we use only `contents: read` unless further mutation is confirmed to occur.

Insert:

```yaml
permissions:
  contents: read
```

at line 2 (before `on:`) in `.github/workflows/issues.yaml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
