### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -6,6 +6,8 @@ on:
       - reopened
       - ready_for_review
 
+permissions:
+  contents: read
 env:
   STORE_ARTEFACTS: true
   RUN_LINTER: true


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/6](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/6)

To fix this problem, we should set an explicit minimal `permissions` block for the workflow (or for each job without one). The minimal approach is to apply it at the workflow root level (above `jobs:`), which ensures all jobs without their own `permissions` block inherit this least-privilege setting. The value should be `contents: read`, which is sufficient for jobs that only need to read repository files (like linting, unit tests, builds, and e2e tests). The jobs `notify_mattermost` and `notify_mastodon` already specify more granular permissions, so they will not be affected.  

**Changes required:**  
- Insert at the top level (after the workflow `name` and `on` but before `env` or `jobs`):  
```yaml
permissions:
  contents: read
```
- No other code changes or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
