### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -27,6 +27,8 @@ jobs:
   unittest:
     name: Run UnitTest
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/11](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/11)

The best way to fix this problem is to add a `permissions` block with minimal privileges required to the `unittest` job definition. Based on the steps listed, the job only needs to check out code and run tests, so `contents: read` is sufficient. This should be added immediately after the `runs-on` key in the `unittest` job, matching the pattern used for the other jobs in the workflow. No extra imports or methods are needed, just an edit to the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
