### PR TITLE
Potential fix for code scanning alert no. 30: Useless assignment to property

### DIFF
--- a/Tests/e2e/playwright/tests/Fixtures/app.ts
+++ b/Tests/e2e/playwright/tests/Fixtures/app.ts
@@ -4,7 +4,7 @@ import {Authentication} from "./authentication";
 export class Application {
     auth: Authentication
 
-    constructor(public readonly page: Page, public timeout?: number) {
+    constructor(public readonly page: Page, timeout?: number) {
         this.timeout = typeof timeout !== "undefined" ? timeout : 60 / 2 * 1000
         this.auth = new Authentication(this)
     }


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/30](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/30)

To fix the problem, remove the redundant assignment of the `timeout` parameter as a public property in the constructor's parameter list. Do this by changing the constructor definition from `constructor(public readonly page: Page, public timeout?: number)` to `constructor(public readonly page: Page, timeout?: number)`. This way, `timeout` is just a local parameter, and its value is assigned to `this.timeout` in the body as before. No additional imports, methods, or definitions are needed.

Edit only the constructor signature in `Tests/e2e/playwright/tests/Fixtures/app.ts`, ensuring that the rest of the logic remains unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
