### PR TITLE
Potential fix for code scanning alert no. 39: Unused variable, import, function or class

### DIFF
--- a/Tests/e2e/playwright/tests/OAuth/Pkce.spec.ts
+++ b/Tests/e2e/playwright/tests/OAuth/Pkce.spec.ts
@@ -3,7 +3,6 @@ import {Application} from "../Fixtures/app";
 import {
     authorizeFormRequest,
     getTokenForAuthorisationCode,
-    getTokenInfo,
     loginAuthorizeFormRequest
 } from "./AuthorizeRequests";
 import { createCodeChallenge, generateCodeVerifier } from './Pkce';


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/39](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/39)

To fix the problem, simply remove the `getTokenInfo` imported identifier from the import statement on lines 3–8 in Tests/e2e/playwright/tests/OAuth/Pkce.spec.ts. Only the named import for `getTokenInfo` should be removed. All other identifiers in the import list must be preserved, as they are used elsewhere in the code snippet. No other changes are needed, and no substitutions or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
