### PR TITLE
Potential fix for code scanning alert no. 40: Unused variable, import, function or class

### DIFF
--- a/Tests/e2e/playwright/tests/OAuth/SilentLoginDisabled.spec.ts
+++ b/Tests/e2e/playwright/tests/OAuth/SilentLoginDisabled.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect, Cookie} from '@playwright/test'
 import {Application} from "../Fixtures/app"
 import {
-    authorizeApiRequest, authorizeApiRequestOnPage,
+    authorizeApiRequestOnPage,
     loginAuthorizeFormRequest
 } from "./AuthorizeRequests"
 


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/40](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/40)

To fix the unused import error, simply remove `authorizeApiRequest` from the import statement on line 4 in `Tests/e2e/playwright/tests/OAuth/SilentLoginDisabled.spec.ts`. Take care not to remove or alter the imports of `authorizeApiRequestOnPage` and `loginAuthorizeFormRequest` if they are in use. Only edit the provided snippet, and make no further changes elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
