### PR TITLE
Potential fix for code scanning alert no. 47: Unused variable, import, function or class

### DIFF
--- a/Tests/e2e/playwright/tests/Translations/pt_PT.spec.ts
+++ b/Tests/e2e/playwright/tests/Translations/pt_PT.spec.ts
@@ -48,7 +48,7 @@ test.describe('Languages - PT', () => {
         const app = new Application(page)
         testInfo.fail(); // This test fails due to missing translations for this page -> UIT-299
 
-        let response = await page.goto('https://uitsmijter.localhost/pageNotFound');
+        await page.goto('https://uitsmijter.localhost/pageNotFound');
         await app.waitForPage();
 
         const field = await page.locator(".error-headline h1");


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/47](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/47)

To fix the problem, simply remove the unused variable `response` from the line in question. Since the awaited navigation action is still required as a side effect (i.e., navigating the page), the best solution is to await the `page.goto()` call without assigning its result to any variable.  
This change should be made in file `Tests/e2e/playwright/tests/Translations/pt_PT.spec.ts` on line 51 within the `test('error translated', ...)` test. No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
