### PR TITLE
Potential fix for code scanning alert no. 38: Unused variable, import, function or class

### DIFF
--- a/Tests/e2e/playwright/tests/OAuth/ImplicitFlow.spec.ts
+++ b/Tests/e2e/playwright/tests/OAuth/ImplicitFlow.spec.ts
@@ -1,7 +1,6 @@
 import {test, expect} from '@playwright/test';
 import {Application} from "../Fixtures/app";
 import {
-    authorizeApiRequest,
     getTokenForAuthorisationCode,
     getTokenInfo,
 } from "./AuthorizeRequests";


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/38](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/38)

To fix the problem, remove `authorizeApiRequest` from the list of imported functions on line 3. This maintans only the used imports and eliminates unnecessary clutter. You should only remove the unused symbol, keeping any imports that are actually referenced in the test code. No other code or imports should be touched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
