### PR TITLE
Potential fix for code scanning alert no. 35: Unused variable, import, function or class

### DIFF
--- a/Tests/e2e/playwright/tests/Interceptor/CheeseCookbookInvalidRefreshUser.spec.ts
+++ b/Tests/e2e/playwright/tests/Interceptor/CheeseCookbookInvalidRefreshUser.spec.ts
@@ -1,6 +1,5 @@
 import {test, expect, Page, Cookie} from '@playwright/test';
 import {Application} from "../Fixtures/app";
-import {Authentication} from "../Fixtures/authentication";
 import {decodeJwt, encodeJwt} from "../OAuth/AuthorizeRequests";
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/uitsmijter/Uitsmijter/security/code-scanning/35](https://github.com/uitsmijter/Uitsmijter/security/code-scanning/35)

To fix this issue, the unused import for `Authentication` should be removed from line 3.  
- Only the import of `{Authentication}` from `"../Fixtures/authentication"` should be deleted.
- No references or usages of `Authentication` are present in the file. So, simply remove this line.
- No changes to existing code functionality will occur since the module and identifier are not being used.

Edit only the import statements at the head of `Tests/e2e/playwright/tests/Interceptor/CheeseCookbookInvalidRefreshUser.spec.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
