### PR TITLE
Add OAuth 2.0 Device Authorization Grant (RFC 8628)

### DIFF
--- a/Deployment/e2e/applications/Ham/tenant.yaml
+++ b/Deployment/e2e/applications/Ham/tenant.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   silent_login: false
   hosts:
+    - id.ham.test
     - page.ham.test
     - shop.ham.test
     - api1.ham.test
@@ -26,7 +27,14 @@ spec:
     - |
       class UserLoginProvider {
         auth = false;
-        constructor(credentials) { this.auth = credentials.username.endsWith("@example.com"); commit(true); }
+        constructor(credentials) {
+          if (credentials.grant_type === 'interceptor' && credentials.username != "allow@example.com") {
+            commit(false);
+            return;
+          }
+          this.auth = credentials.username.endsWith("@example.com");
+          commit(true);
+        }
         get canLogin() { return this.auth; }
         get userProfile() { return { name: "Test User" }; }
         get role() { return "user"; }

--- a/Deployment/e2e/traefik/values.yaml
+++ b/Deployment/e2e/traefik/values.yaml
@@ -1132,8 +1132,6 @@ rbac:  # @schema additionalProperties: false
   # Enable user-facing roles
   # https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
   aggregateTo: []
-  # List of Kubernetes secrets that are accessible for Traefik. If empty, then access is granted to every secret.
-  secretResourceNames: []
 
 # -- Enable to create a PodSecurityPolicy and assign it to the Service Account via RoleBinding or ClusterRoleBinding
 podSecurityPolicy:

--- a/Deployment/e2e/uitsmijter-client.yaml
+++ b/Deployment/e2e/uitsmijter-client.yaml
@@ -39,3 +39,22 @@ spec:
   tenantname: uitsmijter/ham
   redirect_urls:
     - 'https?://(.*\.)?ham.test(:8080)?/.*'
+
+---
+# Device Authorization Grant client used by terminal-login-test
+apiVersion: "uitsmijter.io/v1"
+kind: Client
+metadata:
+  name: terminal-device-client
+spec:
+  ident: f8b3c2a1-0d1e-4f8b-9c2a-3d4e5f6a7b8c
+  tenantname: uitsmijter/uitsmijter-tenant
+  redirect_urls:
+    - 'https?://(.*\.)?localhost(:8080)?/.*'
+  grant_types:
+    - device_code
+  scopes:
+    - access
+  device_grant_config:
+    expires_in: 1800
+    interval: 5

--- a/Deployment/helm/uitsmijter/templates/crd-clients.yaml
+++ b/Deployment/helm/uitsmijter/templates/crd-clients.yaml
@@ -75,6 +75,18 @@ spec:
                   type: boolean
                 secret:
                   type: string
+                device_grant_config:
+                  type: object
+                  properties:
+                    expires_in:
+                      type: integer
+                      description: Lifetime in seconds of device_code and user_code (default 1800)
+                    interval:
+                      type: integer
+                      description: Minimum polling interval in seconds (default 5)
+                    verification_uri:
+                      type: string
+                      description: Override the verification URI shown to the user
               required:
                 - ident
                 - tenantname

--- a/Resources/Translations/de_DE.json
+++ b/Resources/Translations/de_DE.json
@@ -1,4 +1,11 @@
 {
+  "ACTIVATE": {
+    "UI": {
+      "USER_CODE": "Gerätecode (z.B. ABCD-EFGH)",
+      "SUCCESS": "Ihr Gerät wurde erfolgreich autorisiert.",
+      "AUTHORIZE": "Gerät autorisieren"
+    }
+  },
   "LOGIN": {
     "UI": {
       "LOGIN": "Anmelden",

--- a/Resources/Translations/en_EN.json
+++ b/Resources/Translations/en_EN.json
@@ -1,4 +1,11 @@
 {
+  "ACTIVATE": {
+    "UI": {
+      "USER_CODE": "Device Code (e.g. ABCD-EFGH)",
+      "SUCCESS": "Your device has been authorized successfully.",
+      "AUTHORIZE": "Authorize Device"
+    }
+  },
   "LOGIN": {
     "UI": {
       "LOGIN": "Log In",

--- a/Resources/Translations/pt_PT.json
+++ b/Resources/Translations/pt_PT.json
@@ -1,4 +1,11 @@
 {
+  "ACTIVATE": {
+    "UI": {
+      "USER_CODE": "Código do dispositivo (ex. ABCD-EFGH)",
+      "SUCCESS": "O seu dispositivo foi autorizado com sucesso.",
+      "AUTHORIZE": "Autorizar dispositivo"
+    }
+  },
   "LOGIN": {
     "UI": {
       "LOGIN": "Iniciar sessão",

--- a/Resources/Views/default/activate.leaf
+++ b/Resources/Views/default/activate.leaf
@@ -22,11 +22,19 @@
     <div class="logo-box">
         <img src="images/uitsmijter.svg">
     </div>
+
+    #if(success):
+    <div class="login-box">
+        <div class="message" data-result="success">#t("ACTIVATE.UI.SUCCESS")</div>
+    </div>
+    #else:
     <div class='login-box #isnotempty(error, "error")'>
-        <form action="#(serviceUrl)/login" method="post">
-            <input type="hidden" name="location" value="#(requestUri)"/>
-            <input type="hidden" name="mode" value="#(mode)"/>
-            <input type="hidden" name="scope" value="#join("+", requestedScopes)"/>
+        <form action="/activate" method="post">
+            <div class="field">
+                <input type="text" id="user_code" name="user_code" value="#(userCode)"
+                       placeholder='#t("ACTIVATE.UI.USER_CODE")'
+                       autocomplete="off" autocorrect="off" autocapitalize="characters" spellcheck="false">
+            </div>
             <div class="field">
                 <input type="text" id="username" name="username" placeholder='#t("LOGIN.UI.NAME")' autofocus>
             </div>
@@ -36,20 +44,13 @@
             #if(error != nil):
             <div class="error" data-error="#(error)">#t(error)</div>
             #endif
-            #if(requestInfo != nil):
-            <div class="message">#(requestInfo.description)</div>
-            #endif
 
-            <button id="loginButton" type="submit" class="button-big" name="login-button">
-                <span>#t("LOGIN.UI.LOGIN")</span>
-                <svg id="loginSpinner" class="login-spinner login-spinner-invisible" width="16" height="16"
-                     viewBox="0 0 16 16"
-                     xmlns="http://www.w3.org/2000/svg">
-                    <circle cx="8" cy="8" r="8"/>
-                </svg>
+            <button id="activateButton" type="submit" class="button-big" name="activate-button">
+                <span>#t("ACTIVATE.UI.AUTHORIZE")</span>
             </button>
         </form>
     </div>
+    #endif
 </main>
 
 #if(tenant != nil && tenant.config.informations != nil):
@@ -60,9 +61,6 @@
         #endif
         #if(tenant.config.informations.privacy_url != nil):
         <li><a href="#(tenant.config.informations.privacy_url)" data-type="privacy">Datenschutz</a></li>
-        #endif
-        #if(tenant.config.informations.register_url != nil):
-        <li><a href="#(tenant.config.informations.register_url)" data-type="register">Registrieren</a></li>
         #endif
     </ul>
 </footer>

--- a/Sources/FoundationExtensions/String/String+Random.swift
+++ b/Sources/FoundationExtensions/String/String+Random.swift
@@ -39,7 +39,7 @@ public extension String {
         ///
         /// - Parameter characterSet: A string containing all allowed characters
         /// - Returns: A `RandomCharacterSet` with the specified characters
-        static func custom(_ characterSet: String) -> RandomCharacterSet {
+        public static func custom(_ characterSet: String) -> RandomCharacterSet {
             RandomCharacterSet(value: characterSet)
         }
     }

--- a/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage+MemoryImpl.swift
+++ b/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage+MemoryImpl.swift
@@ -40,7 +40,7 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
                 // Already expired, remove immediately
                 if storage.isEmpty == false {
                     let removed = storage.removeLast()
-                    Log.debug("Removing code: \(removed.code.value), TTL: \(String(describing: removed.ttl))")
+                    Log.debug("Removing code: \(removed.codeValue), TTL: \(String(describing: removed.ttl))")
                     gc()
                 }
                 return
@@ -64,7 +64,7 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     private func removeExpired() {
         if storage.isEmpty == false {
             let removed = storage.removeLast()
-            Log.debug("Removing code: \(removed.code.value), TTL: \(String(describing: removed.ttl))")
+            Log.debug("Removing code: \(removed.codeValue), TTL: \(String(describing: removed.ttl))")
             gc()
         }
     }
@@ -76,12 +76,12 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     /// - Parameter session: The authorization session to store
     /// - Throws: `AuthCodeStorageError.CODE_TAKEN` if a session with this code already exists
     func set(authSession session: AuthSession) async throws {
-        if storage.contains(where: { $0.code.value == session.code.value }) {
+        if storage.contains(where: { $0.codeValue == session.codeValue }) {
             throw AuthCodeStorageError.CODE_TAKEN
         }
         Log.debug(
             """
-            Storing new session - Type: \(session.type.rawValue), \
+            Storing new session - Type: \(session.sessionType.rawValue), \
             Tenant: \(session.payload?.tenant ?? "nil"), \
             Subject: \(session.payload?.subject.value ?? "nil"), \
             TTL: \(String(describing: session.ttl))
@@ -95,14 +95,14 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     /// Retrieves an authorization session by code value.
     ///
     /// - Parameters:
-    ///   - type: The type of authorization code (code or refresh)
+    ///   - type: The type of authorization code (code, refresh, or device)
     ///   - value: The authorization code value to look up
     ///   - remove: If true, removes the session after retrieval (single-use enforcement)
     /// - Returns: The authorization session if found, nil otherwise
-    func get(type: AuthSession.CodeType, codeValue value: String, remove: Bool? = false) async -> AuthSession? {
-        let session = storage.first(where: { $0.code.value == value && $0.type == type })
+    func get(type: AuthSessionType, codeValue value: String, remove: Bool? = false) async -> AuthSession? {
+        let session = storage.first(where: { $0.codeValue == value && $0.sessionType == type })
         if remove ?? false {
-            storage.removeAll(where: { $0.code.value == value && $0.type == type })
+            storage.removeAll(where: { $0.codeValue == value && $0.sessionType == type })
         }
         return session
     }
@@ -142,11 +142,11 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     /// Deletes an authorization session by code value.
     ///
     /// - Parameters:
-    ///   - type: The type of authorization code (code or refresh)
+    ///   - type: The type of authorization code (code, refresh, or device)
     ///   - value: The authorization code value to delete
     /// - Throws: Can throw errors from storage operations
-    func delete(type: AuthSession.CodeType, codeValue value: String) async throws {
-        storage.removeAll(where: { $0.code.value == value && $0.type == type })
+    func delete(type: AuthSessionType, codeValue value: String) async throws {
+        storage.removeAll(where: { $0.codeValue == value && $0.sessionType == type })
     }
 
     /// Removes all authorization sessions for a specific user.
@@ -164,7 +164,7 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
             if matches {
                 Log.debug(
                     """
-                    Matching session found - Type: \(session.type.rawValue), \
+                    Matching session found - Type: \(session.sessionType.rawValue), \
                     Tenant: \(session.payload?.tenant ?? "nil"), \
                     Subject: \(session.payload?.subject.value ?? "nil")
                     """
@@ -184,15 +184,15 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     ///   - tenant: The tenant to count sessions for
     ///   - type: The type of sessions to count (e.g., .refresh for long-lived sessions)
     /// - Returns: The number of sessions matching the criteria
-    func count(tenant: Tenant, type: AuthSession.CodeType) async -> Int {
-        let matchingSessions = storage.filter { $0.payload?.tenant == tenant.name && $0.type == type }
+    func count(tenant: Tenant, type: AuthSessionType) async -> Int {
+        let matchingSessions = storage.filter { $0.payload?.tenant == tenant.name && $0.sessionType == type }
         Log.debug("Count called for tenant: \(tenant.name), type: \(type.rawValue) - found \(matchingSessions.count)")
 
         // Log details of each matching session for debugging
         for session in matchingSessions {
             Log.debug(
                 """
-                Session in count - Type: \(session.type.rawValue), \
+                Session in count - Type: \(session.sessionType.rawValue), \
                 Tenant: \(session.payload?.tenant ?? "nil"), \
                 Subject: \(session.payload?.subject.value ?? "nil")
                 """
@@ -208,13 +208,13 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
     ///   - client: The client to count sessions for
     ///   - type: The type of sessions to count (e.g., .refresh for long-lived sessions)
     /// - Returns: The number of sessions matching the criteria
-    func count(client: UitsmijterClient, type: AuthSession.CodeType) async -> Int {
+    func count(client: UitsmijterClient, type: AuthSessionType) async -> Int {
         let clientIdString = client.config.ident.uuidString
         let matchingSessions = storage.filter { session in
             // Match by audience (client_id) in the payload
             guard let payload = session.payload else { return false }
             let audienceMatches = payload.audience.value.contains(clientIdString)
-            return audienceMatches && session.type == type
+            return audienceMatches && session.sessionType == type
         }
         Log.debug("Count called for client: \(client.name), type: \(type.rawValue) - found \(matchingSessions.count)")
 
@@ -222,7 +222,7 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
         for session in matchingSessions {
             Log.debug(
                 """
-                Session in count - Type: \(session.type.rawValue), \
+                Session in count - Type: \(session.sessionType.rawValue), \
                 Client: \(session.payload?.audience.value.joined(separator: ",") ?? "nil"), \
                 Subject: \(session.payload?.subject.value ?? "nil")
                 """
@@ -230,6 +230,56 @@ actor MemoryAuthCodeStorage: AuthCodeStorageProtocol {
         }
 
         return matchingSessions.count
+    }
+
+    /// Retrieves a device session by the short user code entered at the activation page.
+    ///
+    /// - Parameter userCode: The user-facing code (e.g. "ABCD-EFGH")
+    /// - Returns: The matching device session, or nil if not found
+    func getDevice(byUserCode userCode: String) async -> AuthSession? {
+        storage.first { authSession in
+            guard case .device(let deviceSession) = authSession else { return false }
+            return deviceSession.userCode == userCode
+        }
+    }
+
+    /// Updates an existing device session's status, payload, and last-polled timestamp.
+    ///
+    /// - Parameters:
+    ///   - deviceCode: The device code identifying the session
+    ///   - newStatus: The new device grant status
+    ///   - payload: The authorized user payload (nil when still pending)
+    ///   - lastPolledAt: The time the device last polled the token endpoint
+    /// - Throws: `AuthCodeStorageError.KEY_ERROR` if no matching session is found
+    func updateDevice(
+        deviceCode: String,
+        newStatus: DeviceGrantStatus,
+        payload: Payload?,
+        lastPolledAt: Date?
+    ) async throws {
+        guard let index = storage.firstIndex(where: { authSession in
+            guard case .device(let session) = authSession else { return false }
+            return session.deviceCode.value == deviceCode
+        }) else {
+            throw AuthCodeStorageError.KEY_ERROR
+        }
+
+        guard case .device(let existing) = storage[index] else {
+            throw AuthCodeStorageError.KEY_ERROR
+        }
+
+        let updated = DeviceSession(
+            clientId: existing.clientId,
+            deviceCode: existing.deviceCode,
+            userCode: existing.userCode,
+            scopes: existing.scopes,
+            payload: payload,
+            status: newStatus,
+            lastPolledAt: lastPolledAt,
+            ttl: existing.ttl,
+            generated: existing.generated
+        )
+        storage[index] = .device(updated)
     }
 
     /// Checks if the storage backend is healthy and operational.

--- a/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage+RedisImpl.swift
+++ b/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage+RedisImpl.swift
@@ -2,10 +2,14 @@ import Foundation
 @preconcurrency import Redis
 import Logger
 
+// swiftlint:disable type_body_length
 /// Actor-based thread-safe Redis storage for authorization codes and login sessions
 actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
     /// TTL for login session IDs in seconds (2 hours)
     private static let loginSessionTTL: Int64 = 60 * 120
+
+    /// Redis key prefix for secondary device-user-code index
+    private static let deviceUserPrefix = "deviceuser~"
 
     /// Injected redis client
     let redis: RedisClient
@@ -17,7 +21,7 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
     // MARK: - AuthCodeStorageProtocol
 
     func set(authSession session: AuthSession) async throws {
-        guard let key = RedisKey(rawValue: "\(session.type)~" + session.code.value) else {
+        guard let key = RedisKey(rawValue: "\(session.sessionType.rawValue)~" + session.codeValue) else {
             throw AuthCodeStorageError.KEY_ERROR
         }
 
@@ -27,10 +31,21 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         if let ttl = session.ttl {
             _ = try await redis.expire(key, after: TimeAmount.seconds(ttl)).get()
         }
+
+        // For device sessions: also store a secondary key usercode → deviceCode for user-code lookup
+        if case .device(let deviceSession) = session {
+            let userCodeKey = RedisKey(rawValue: Self.deviceUserPrefix + deviceSession.userCode)
+            if let userCodeKey {
+                try await redis.set(userCodeKey, to: deviceSession.deviceCode.value).get()
+                if let ttl = session.ttl {
+                    _ = try await redis.expire(userCodeKey, after: TimeAmount.seconds(ttl)).get()
+                }
+            }
+        }
     }
 
-    func get(type: AuthSession.CodeType, codeValue value: String, remove: Bool? = false) async -> AuthSession? {
-        guard let key = RedisKey(rawValue: "\(type)~" + value) else {
+    func get(type: AuthSessionType, codeValue value: String, remove: Bool? = false) async -> AuthSession? {
+        guard let key = RedisKey(rawValue: "\(type.rawValue)~" + value) else {
             return nil
         }
         let value = try? await redis.get(key).get()
@@ -98,10 +113,21 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         return false
     }
 
-    func delete(type: AuthSession.CodeType, codeValue value: String) async throws {
-        guard let key = RedisKey(rawValue: "\(type)~" + value) else {
+    func delete(type: AuthSessionType, codeValue value: String) async throws {
+        guard let key = RedisKey(rawValue: "\(type.rawValue)~" + value) else {
             return
         }
+
+        // For device sessions: also delete the secondary user-code index
+        if type == .device {
+            if let existing = await get(type: .device, codeValue: value, remove: false),
+               case .device(let deviceSession) = existing {
+                if let userCodeKey = RedisKey(rawValue: Self.deviceUserPrefix + deviceSession.userCode) {
+                    _ = try? await redis.delete([userCodeKey]).get()
+                }
+            }
+        }
+
         _ = try await redis.delete(key).get()
     }
 
@@ -112,8 +138,8 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
             let keysToDelete: [RedisKey] = try await withThrowingTaskGroup(of: RedisKey?.self) { group in
                 for key in keys {
                     group.addTask {
-                        // Skip non-AuthSession keys (loginid~ keys are LoginSession, not AuthSession)
-                        if key.hasPrefix("loginid~") {
+                        // Skip non-AuthSession keys
+                        if key.hasPrefix("loginid~") || key.hasPrefix(Self.deviceUserPrefix) {
                             return nil
                         }
 
@@ -124,7 +150,7 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
                                 if decoded.payload?.tenant == tenant.name && decoded.payload?.subject.value == subject {
                                     Log.debug(
                                         """
-                                        Matching session found in Redis - Type: \(decoded.type.rawValue), \
+                                        Matching session found in Redis - Type: \(decoded.sessionType.rawValue), \
                                         Tenant: \(decoded.payload?.tenant ?? "nil"), \
                                         Subject: \(decoded.payload?.subject.value ?? "nil"), \
                                         Key: \(key)
@@ -156,28 +182,26 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         }
     }
 
-    func count(tenant: Tenant, type: AuthSession.CodeType) async -> Int {
+    func count(tenant: Tenant, type: AuthSessionType) async -> Int {
         Log.debug("Count AuthSession for tenant: \(tenant.name) with type: \(type.rawValue)")
         do {
             let (_, keys) = try await redis.scan(startingFrom: 0).get()
             let matchingKeys: Int = try await withThrowingTaskGroup(of: Int.self) { group in
                 for key in keys {
                     group.addTask {
-                        // Skip non-AuthSession keys (loginid~ keys are LoginSession, not AuthSession)
-                        if key.hasPrefix("loginid~") {
+                        // Skip non-AuthSession keys
+                        if key.hasPrefix("loginid~") || key.hasPrefix(Self.deviceUserPrefix) {
                             return 0
                         }
 
                         if let rKey = RedisKey(rawValue: key) {
                             let value = try? await self.redis.get(rKey).get()
                             if let data = value?.data {
-                                // Try to decode as AuthSession, but skip if it's a different type
-                                // (e.g., LoginSession which doesn't have a 'type' field)
                                 if let decoded = try? JSONDecoder.main.decode(AuthSession.self, from: data) {
-                                    if decoded.payload?.tenant == tenant.name && decoded.type == type {
+                                    if decoded.payload?.tenant == tenant.name && decoded.sessionType == type {
                                         Log.debug(
                                             """
-                                            Session in count - Type: \(decoded.type.rawValue), \
+                                            Session in count - Type: \(decoded.sessionType.rawValue), \
                                             Tenant: \(decoded.payload?.tenant ?? "nil"), \
                                             Subject: \(decoded.payload?.subject.value ?? "nil"), \
                                             Key: \(key)
@@ -206,31 +230,29 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         }
     }
 
-    func count(client: UitsmijterClient, type: AuthSession.CodeType) async -> Int {
+    func count(client: UitsmijterClient, type: AuthSessionType) async -> Int {
         Log.debug("Count AuthSession for client: \(client.name) with type: \(type.rawValue)")
         do {
             let (_, keys) = try await redis.scan(startingFrom: 0).get()
             let matchingKeys: Int = try await withThrowingTaskGroup(of: Int.self) { group in
                 for key in keys {
                     group.addTask {
-                        // Skip non-AuthSession keys (loginid~ keys are LoginSession, not AuthSession)
-                        if key.hasPrefix("loginid~") {
+                        // Skip non-AuthSession keys
+                        if key.hasPrefix("loginid~") || key.hasPrefix(Self.deviceUserPrefix) {
                             return 0
                         }
 
                         if let rKey = RedisKey(rawValue: key) {
                             let value = try? await self.redis.get(rKey).get()
                             if let data = value?.data {
-                                // Try to decode as AuthSession, but skip if it's a different type
                                 if let decoded = try? JSONDecoder.main.decode(AuthSession.self, from: data) {
-                                    // Match by audience (client_id) in the payload and type
                                     guard let payload = decoded.payload else { return 0 }
                                     let clientIdString = client.config.ident.uuidString
                                     let audienceMatches = payload.audience.value.contains(clientIdString)
-                                    if audienceMatches && decoded.type == type {
+                                    if audienceMatches && decoded.sessionType == type {
                                         Log.debug(
                                             """
-                                            Session in count - Type: \(decoded.type.rawValue), \
+                                            Session in count - Type: \(decoded.sessionType.rawValue), \
                                             Client: \(payload.audience.value.joined(separator: ",")), \
                                             Subject: \(payload.subject.value), \
                                             Key: \(key)
@@ -259,6 +281,48 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         }
     }
 
+    /// Retrieves a device session by the short user code via secondary index.
+    func getDevice(byUserCode userCode: String) async -> AuthSession? {
+        guard let userCodeKey = RedisKey(rawValue: Self.deviceUserPrefix + userCode) else {
+            return nil
+        }
+        guard let deviceCodeValue = try? await redis.get(userCodeKey).get(),
+              let deviceCodeString = deviceCodeValue.string else {
+            return nil
+        }
+        return await get(type: .device, codeValue: deviceCodeString)
+    }
+
+    /// Updates a device session: deletes the old entry and stores the updated session.
+    func updateDevice(
+        deviceCode: String,
+        newStatus: DeviceGrantStatus,
+        payload: Payload?,
+        lastPolledAt: Date?
+    ) async throws {
+        guard let existing = await get(type: .device, codeValue: deviceCode),
+              case .device(let deviceSession) = existing else {
+            throw AuthCodeStorageError.KEY_ERROR
+        }
+
+        // Delete the old session (also removes secondary user-code key)
+        try await delete(type: .device, codeValue: deviceCode)
+
+        // Store the updated session
+        let updated = DeviceSession(
+            clientId: deviceSession.clientId,
+            deviceCode: deviceSession.deviceCode,
+            userCode: deviceSession.userCode,
+            scopes: deviceSession.scopes,
+            payload: payload,
+            status: newStatus,
+            lastPolledAt: lastPolledAt,
+            ttl: deviceSession.ttl,
+            generated: deviceSession.generated
+        )
+        try await set(authSession: .device(updated))
+    }
+
     func isHealthy() async -> Bool {
         if (try? await redis.ping().get()) == "PONG" {
             return true
@@ -268,3 +332,4 @@ actor RedisAuthCodeStorage: AuthCodeStorageProtocol {
         return false
     }
 }
+// swiftlint:enable type_body_length

--- a/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage.swift
+++ b/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorage.swift
@@ -128,7 +128,7 @@ struct AuthCodeStorage: AuthCodeStorageProtocol, Sendable {
         thread.main()
     }
 
-    /// Retrieves an authorization session by its code type and value.
+    /// Retrieves an authorization session by its session type and value.
     ///
     /// - Parameters:
     ///   - codeType: The type of code to retrieve (e.g., `.code` for authorization codes, `.refresh` for refresh tokens).
@@ -150,7 +150,7 @@ struct AuthCodeStorage: AuthCodeStorageProtocol, Sendable {
     /// }
     /// ```
     func get(
-        type codeType: AuthSession.CodeType,
+        type codeType: AuthSessionType,
         codeValue value: String,
         remove: Bool? = false
     ) async -> AuthSession? {
@@ -193,7 +193,7 @@ struct AuthCodeStorage: AuthCodeStorageProtocol, Sendable {
         return await implementation.count()
     }
 
-    /// Deletes a specific authorization session by its code type and value.
+    /// Deletes a specific authorization session by its session type and value.
     ///
     /// This method is used to explicitly invalidate a code or token, such as when a user
     /// logs out or when a token is revoked.
@@ -202,7 +202,7 @@ struct AuthCodeStorage: AuthCodeStorageProtocol, Sendable {
     ///   - codeType: The type of code to delete.
     ///   - value: The unique code value to remove.
     /// - Throws: An error if the delete operation fails.
-    func delete(type codeType: AuthSession.CodeType, codeValue value: String) async throws {
+    func delete(type codeType: AuthSessionType, codeValue value: String) async throws {
         Log.debug("Delete AuthSession for type \(codeType.rawValue) with value: \(value)")
         try await implementation.delete(type: codeType, codeValue: value)
     }
@@ -229,50 +229,49 @@ struct AuthCodeStorage: AuthCodeStorageProtocol, Sendable {
 
     /// Counts sessions for a specific tenant and type.
     ///
-    /// This method filters sessions to count only those belonging to a specific tenant
-    /// and of a specific type (e.g., refresh tokens to count active user sessions).
-    ///
     /// - Parameters:
     ///   - tenant: The tenant to count sessions for.
     ///   - type: The type of sessions to count (e.g., `.refresh` for long-lived sessions).
     /// - Returns: The number of sessions matching the criteria.
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// // Count active user sessions (refresh tokens) for a tenant
-    /// let sessionCount = await storage.count(tenant: myTenant, type: .refresh)
-    /// ```
-    func count(tenant: Tenant, type: AuthSession.CodeType) async -> Int {
+    func count(tenant: Tenant, type: AuthSessionType) async -> Int {
         Log.debug("Count AuthSession for tenant: \(tenant.name) with type: \(type.rawValue)")
         return await implementation.count(tenant: tenant, type: type)
     }
 
     /// Counts the number of authorization sessions for a specific client and type.
     ///
-    /// This method is useful for metrics and monitoring, allowing you to track how many
-    /// sessions exist for a particular client (OAuth2 application).
-    ///
     /// - Parameters:
     ///   - client: The client to count sessions for
     ///   - type: The type of sessions to count (defaults to .refresh for long-lived sessions)
     /// - Returns: The number of sessions matching the specified client and type
-    ///
-    /// ## Example
-    ///
-    /// ```swift
-    /// // Count active user sessions (refresh tokens) for a client
-    /// let sessionCount = await storage.count(client: myClient, type: .refresh)
-    /// ```
-    func count(client: UitsmijterClient, type: AuthSession.CodeType) async -> Int {
+    func count(client: UitsmijterClient, type: AuthSessionType) async -> Int {
         Log.debug("Count AuthSession for client: \(client.name) with type: \(type.rawValue)")
         return await implementation.count(client: client, type: type)
     }
 
+    /// Retrieve a device session by the short user code entered at the activation endpoint.
+    func getDevice(byUserCode userCode: String) async -> AuthSession? {
+        Log.debug("Get device session by userCode: \(userCode)")
+        return await implementation.getDevice(byUserCode: userCode)
+    }
+
+    /// Update an existing device session's status, payload, and last-polled timestamp.
+    func updateDevice(
+        deviceCode: String,
+        newStatus: DeviceGrantStatus,
+        payload: Payload?,
+        lastPolledAt: Date?
+    ) async throws {
+        Log.debug("Update device session \(deviceCode) → \(newStatus.rawValue)")
+        try await implementation.updateDevice(
+            deviceCode: deviceCode,
+            newStatus: newStatus,
+            payload: payload,
+            lastPolledAt: lastPolledAt
+        )
+    }
+
     /// Checks whether the storage backend is operational and able to serve requests.
-    ///
-    /// This health check is used by monitoring systems to verify the availability of
-    /// the storage layer. For Redis backends, this typically involves a ping operation.
     ///
     /// - Returns: `true` if the storage is healthy, `false` otherwise.
     func isHealthy() async -> Bool {

--- a/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorageProtocol.swift
+++ b/Sources/Uitsmijter-AuthServer/AuthCodeStorage/AuthCodeStorageProtocol.swift
@@ -7,7 +7,7 @@ protocol AuthCodeStorageProtocol: Sendable {
     func set(authSession: AuthSession) async throws
 
     /// Retrieve an authorization session by type and code value
-    func get(type: AuthSession.CodeType, codeValue: String, remove: Bool?) async -> AuthSession?
+    func get(type: AuthSessionType, codeValue: String, remove: Bool?) async -> AuthSession?
 
     /// Push a login session
     func push(loginId: LoginSession) async throws
@@ -19,7 +19,7 @@ protocol AuthCodeStorageProtocol: Sendable {
     func count() async -> Int
 
     /// Delete a specific session by type and code value
-    func delete(type: AuthSession.CodeType, codeValue: String) async throws
+    func delete(type: AuthSessionType, codeValue: String) async throws
 
     /// Wipe all sessions for a specific tenant and subject
     func wipe(tenant: Tenant, subject: String) async
@@ -29,14 +29,25 @@ protocol AuthCodeStorageProtocol: Sendable {
     ///   - tenant: The tenant to count sessions for
     ///   - type: The type of sessions to count (defaults to .refresh for long-lived sessions)
     /// - Returns: The number of sessions matching the criteria
-    func count(tenant: Tenant, type: AuthSession.CodeType) async -> Int
+    func count(tenant: Tenant, type: AuthSessionType) async -> Int
 
     /// Count sessions for a specific client and type
     /// - Parameters:
     ///   - client: The client to count sessions for
     ///   - type: The type of sessions to count (defaults to .refresh for long-lived sessions)
     /// - Returns: The number of sessions matching the criteria
-    func count(client: UitsmijterClient, type: AuthSession.CodeType) async -> Int
+    func count(client: UitsmijterClient, type: AuthSessionType) async -> Int
+
+    /// Retrieve a device session by the user code entered at the activation endpoint
+    func getDevice(byUserCode userCode: String) async -> AuthSession?
+
+    /// Update an existing device session's status and optional payload
+    func updateDevice(
+        deviceCode: String,
+        newStatus: DeviceGrantStatus,
+        payload: Payload?,
+        lastPolledAt: Date?
+    ) async throws
 
     /// Check if the storage is healthy
     func isHealthy() async -> Bool

--- a/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
@@ -1,0 +1,271 @@
+import Foundation
+import Vapor
+import JWT
+import Logger
+
+/// Template context for the device activation page.
+struct ActivatePageProperties: Encodable, Sendable {
+    let title: String
+    var error: String?
+    var success: Bool
+    var userCode: String?
+    var tenant: Tenant?
+
+    init(
+        title: String = "Activate Device",
+        error: String? = nil,
+        success: Bool = false,
+        userCode: String? = nil,
+        tenant: Tenant? = nil
+    ) {
+        self.title = title
+        self.error = error
+        self.success = success
+        self.userCode = userCode
+        self.tenant = tenant
+    }
+}
+
+/// Controller for the device activation endpoint (RFC 8628, Section 3.3).
+///
+/// Users visit `GET /activate` on their browser, enter the `user_code` shown on
+/// the device, and authenticate. On success the device session is marked as
+/// `authorized` so the device's next poll at `POST /token` returns the access token.
+///
+/// ## Route Registration
+///
+/// - `GET /activate` — displays the activation form
+/// - `POST /activate` — processes user_code + credentials
+struct ActivateController: RouteCollection {
+
+    func boot(routes: RoutesBuilder) throws {
+        let activate = routes.grouped("activate")
+        activate.get(use: { @Sendable (req: Request) async throws -> Response in
+            try await self.getActivate(req: req)
+        })
+        activate.post(use: { @Sendable (req: Request) async throws -> Response in
+            try await self.doActivate(req: req)
+        })
+    }
+
+    // MARK: - GET /activate
+
+    @Sendable func getActivate(req: Request) async throws -> Response {
+        let userCode: String? = try? req.query.get(at: "user_code")
+
+        // If user_code is present and a valid JWT cookie exists, auto-authorize
+        if let rawCode = userCode,
+           let payload = try? await req.jwt.verify(as: Payload.self),
+           (try? payload.expiration.verifyNotExpired(currentDate: Date())) != nil {
+
+            let normalized = normalizeUserCode(rawCode)
+
+            guard let storage = req.application.authCodeStorage else {
+                return try await renderActivateView(req: req, status: .internalServerError, props: .init(
+                    error: "ERRORS.STORAGE_UNAVAILABLE"
+                ))
+            }
+
+            if let deviceSession = await storage.getDevice(byUserCode: normalized),
+               case .device(let deviceData) = deviceSession,
+               deviceData.status == .pending {
+                try await storage.updateDevice(
+                    deviceCode: deviceSession.codeValue,
+                    newStatus: .authorized,
+                    payload: payload,
+                    lastPolledAt: nil
+                )
+                Prometheus.main.deviceFlowAuthorized?.inc()
+                Log.info("Device authorized via cookie for userCode: \(normalized)", requestId: req.id)
+                return try await renderActivateView(req: req, status: .ok, props: .init(success: true))
+            }
+        }
+
+        return try await renderActivateView(req: req, status: .ok, props: .init(userCode: userCode))
+    }
+
+    // MARK: - POST /activate
+
+    // swiftlint:disable:next function_body_length cyclomatic_complexity
+    @Sendable func doActivate(req: Request) async throws -> Response {
+        guard let rawCode: String = try? req.content.get(at: "user_code"), !rawCode.isEmpty else {
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ACTIVATE.ERRORS.MISSING_CODE"
+            ))
+        }
+
+        let normalized = normalizeUserCode(rawCode)
+
+        guard let storage = req.application.authCodeStorage else {
+            return try await renderActivateView(req: req, status: .internalServerError, props: .init(
+                error: "ERRORS.STORAGE_UNAVAILABLE"
+            ))
+        }
+
+        guard let deviceSession = await storage.getDevice(byUserCode: normalized) else {
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ACTIVATE.ERRORS.INVALID_CODE",
+                userCode: rawCode
+            ))
+        }
+
+        guard case .device(let deviceData) = deviceSession, deviceData.status == .pending else {
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ACTIVATE.ERRORS.CODE_ALREADY_USED",
+                userCode: rawCode
+            ))
+        }
+
+        // If the user already has a valid JWT cookie, authorize immediately without credentials
+        if let payload = try? await req.jwt.verify(as: Payload.self),
+           (try? payload.expiration.verifyNotExpired(currentDate: Date())) != nil {
+            try await storage.updateDevice(
+                deviceCode: deviceSession.codeValue,
+                newStatus: .authorized,
+                payload: payload,
+                lastPolledAt: nil
+            )
+            Prometheus.main.deviceFlowAuthorized?.inc()
+            Log.info("Device authorized via cookie for userCode: \(normalized)", requestId: req.id)
+            return try await renderActivateView(req: req, status: .ok, props: .init(success: true))
+        }
+
+        // No cookie → authenticate with submitted credentials
+        guard let username: String = try? req.content.get(at: "username"),
+              let password: String = try? req.content.get(at: "password"),
+              !username.isEmpty else {
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ACTIVATE.ERRORS.CREDENTIALS_REQUIRED",
+                userCode: rawCode
+            ))
+        }
+
+        // Find client and tenant from the device session
+        guard let client = await Client.find(
+            in: req.application.entityStorage,
+            clientId: deviceData.clientId
+        ) else {
+            Log.error("Client \(deviceData.clientId) not found for device session", requestId: req.id)
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ACTIVATE.ERRORS.INVALID_CODE",
+                userCode: rawCode
+            ))
+        }
+
+        guard let tenant = await client.config.tenant(in: req.application.entityStorage) else {
+            Log.error("Tenant not found for client \(deviceData.clientId)", requestId: req.id)
+            return try await renderActivateView(req: req, status: .badRequest, props: .init(
+                error: "ERRORS.NO_TENANT",
+                userCode: rawCode
+            ))
+        }
+
+        // Authenticate via JavaScript provider
+        let providerInterpreter = JavaScriptProvider()
+        try await providerInterpreter.loadProvider(
+            script: tenant.config.providers.joined(separator: "\n")
+        )
+        try await providerInterpreter.start(
+            class: .userLogin,
+            arguments: JSInputCredentials(
+                username: username,
+                password: password,
+                grantType: .device_code
+            )
+        )
+
+        guard await providerInterpreter.canLogin() else {
+            Log.info("Activate: cannot log in user \(username)", requestId: req.id)
+            Prometheus.main.loginFailure?.inc()
+            return try await renderActivateView(req: req, status: .forbidden, props: .init(
+                error: "LOGIN.ERRORS.WRONG_CREDENTIALS",
+                userCode: rawCode,
+                tenant: tenant
+            ))
+        }
+
+        // Build payload from provider results
+        let providedSubject: SubjectProtocol = await providerInterpreter.getSubject(
+            loginHandle: username
+        )
+        let profile = await providerInterpreter.getProfile()
+        let role = await providerInterpreter.getRole()
+        let providerScopes = await providerInterpreter.getScopes()
+
+        let scheme = req.headers.first(name: "X-Forwarded-Proto")
+            ?? (Constants.TOKEN.isSecure ? "https" : "http")
+        let host = req.headers.first(name: "X-Forwarded-Host")
+            ?? req.headers.first(name: "Host")
+            ?? tenant.config.hosts.first
+            ?? Constants.PUBLIC_DOMAIN
+        let issuer = "\(scheme)://\(host)"
+
+        let expirationDate = Calendar.current.date(
+            byAdding: .day,
+            value: Constants.COOKIE.EXPIRATION_DAYS,
+            to: Date()
+        ) ?? Date(timeIntervalSinceNow: Double(Constants.COOKIE.EXPIRATION_DAYS) * 86_400)
+
+        let finalScopes = Array(Set(deviceData.scopes + providerScopes)).sorted()
+        let now = Date()
+        let payload = Payload(
+            issuer: IssuerClaim(value: issuer),
+            subject: providedSubject.subject,
+            audience: AudienceClaim(value: deviceData.clientId),
+            expiration: ExpirationClaim(value: expirationDate),
+            issuedAt: IssuedAtClaim(value: now),
+            authTime: AuthTimeClaim(value: now),
+            tenant: tenant.name,
+            responsibility: "",
+            role: role,
+            user: username,
+            scope: finalScopes.joined(separator: " "),
+            profile: profile
+        )
+
+        try await storage.updateDevice(
+            deviceCode: deviceSession.codeValue,
+            newStatus: .authorized,
+            payload: payload,
+            lastPolledAt: nil
+        )
+
+        Prometheus.main.deviceFlowAuthorized?.inc()
+        Prometheus.main.loginSuccess?.inc()
+        Log.info(
+            "Device authorized for userCode: \(normalized) by user: \(username)",
+            requestId: req.id
+        )
+
+        return try await renderActivateView(req: req, status: .ok, props: .init(
+            success: true,
+            tenant: tenant
+        ))
+    }
+
+    // MARK: - Helpers
+
+    private func normalizeUserCode(_ raw: String) -> String {
+        let stripped = raw.uppercased().filter { $0.isLetter || $0.isNumber }
+        if stripped.count == 8 {
+            return "\(stripped.prefix(4))-\(stripped.suffix(4))"
+        }
+        return raw.uppercased()
+    }
+
+    private func renderActivateView(
+        req: Request,
+        status: HTTPResponseStatus,
+        props: ActivatePageProperties
+    ) async throws -> Response {
+        // Activate is a cross-tenant endpoint — it bypasses RequestClientMiddleware,
+        // so clientInfo?.tenant is nil. Fall back to the default activate template
+        // instead of the error template that Template.getPath would return for nil tenant.
+        let templatePath = req.clientInfo?.tenant != nil
+            ? Template.getPath(page: "activate", request: req)
+            : "default/activate"
+        return try await req.view.render(templatePath, props)
+            .flatMap { $0.encodeResponse(status: status, for: req) }
+            .get()
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/Controllers/AuthorizeController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/AuthorizeController.swift
@@ -303,15 +303,14 @@ struct AuthorizeController: RouteCollection, OAuthControllerProtocol {
         // Update payload with the merged scopes for this authorization
         var updatedPayload = userPayload
         updatedPayload.scope = finalScopes.joined(separator: " ")
-        let authSession = AuthSession(
-            type: .code,
+        let authSession = AuthSession.code(CodeSession(
             state: authRequest.state,
             code: code,
             scopes: finalScopes,
             payload: updatedPayload,
             redirect: redirect,
             ttl: Constants.AUTHCODE.TimeToLive
-        )
+        ))
 
         try await request.application.authCodeStorage?.set(authSession: authSession)
         return authSession.codeRedirect(to: request)
@@ -389,15 +388,14 @@ struct AuthorizeController: RouteCollection, OAuthControllerProtocol {
         // Update payload with the merged scopes for this authorization
         var updatedPayload = userPayload
         updatedPayload.scope = finalScopes.joined(separator: " ")
-        let authSession = AuthSession(
-            type: .code,
+        let authSession = AuthSession.code(CodeSession(
             state: authRequest.state,
             code: code,
             scopes: finalScopes,
             payload: updatedPayload,
             redirect: redirect,
             ttl: Constants.AUTHCODE.TimeToLive
-        )
+        ))
 
         try await request.application.authCodeStorage?.set(authSession: authSession)
         return authSession.codeRedirect(to: request)

--- a/Sources/Uitsmijter-AuthServer/Controllers/DeviceController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/DeviceController.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Vapor
+import Logger
+
+/// Controller for the Device Authorization endpoint (RFC 8628, Section 3.1–3.2).
+///
+/// Clients call `POST /oauth/device_authorization` to initiate a device authorization flow.
+/// The response contains a `device_code` for polling the token endpoint and a short
+/// `user_code` that the user enters at the verification URI on another device.
+///
+/// ## Flow
+///
+/// 1. Device posts `client_id` (and optional `scope`) to this endpoint.
+/// 2. Server returns `device_code`, `user_code`, `verification_uri`, `expires_in`, `interval`.
+/// 3. Device displays `user_code` and `verification_uri` to the user.
+/// 4. Device polls `POST /token` with `grant_type=device_code` at `interval`-second intervals.
+/// 5. User visits `verification_uri`, logs in, and enters `user_code`.
+/// 6. Next poll returns the access token.
+///
+/// - SeeAlso: ``DeviceAuthorizationRequest``, ``DeviceAuthorizationResponse``
+struct DeviceController: RouteCollection, OAuthControllerProtocol {
+
+    func boot(routes: RoutesBuilder) throws {
+        let oauth = routes.grouped("oauth")
+        oauth.post("device_authorization", use: { @Sendable (req: Request) async throws -> Response in
+            try await self.authorize(req: req)
+        })
+    }
+
+    // MARK: - Route Handler
+
+    @Sendable func authorize(req: Request) async throws -> Response {
+        let deviceRequest = try req.content.decode(DeviceAuthorizationRequest.self)
+
+        // Validate client
+        let uitsmijterClient = try await client(for: deviceRequest, request: req)
+
+        // Device grant must be configured for the client
+        guard let grantConfig = uitsmijterClient.config.device_grant_config else {
+            Log.error(
+                "device_grant_config not configured for client \(deviceRequest.client_id)",
+                requestId: req.id
+            )
+            throw Abort(.badRequest, reason: "ERRORS.DEVICE_GRANT_NOT_CONFIGURED")
+        }
+
+        // Client must explicitly allow device_code grant type
+        let grantTypes = uitsmijterClient.config.grant_types ?? []
+        guard grantTypes.contains(GrantTypes.device_code.rawValue) else {
+            Log.error(
+                "device_code grant not enabled for client \(deviceRequest.client_id)",
+                requestId: req.id
+            )
+            throw Abort(.badRequest, reason: "ERRORS.GRANT_TYPE_NOT_SUPPORTED")
+        }
+
+        let expiresIn = grantConfig.expires_in ?? 1800
+        let interval = grantConfig.interval ?? 5
+
+        // Determine verification URI
+        let verificationUri: String
+        if let configuredUri = grantConfig.verification_uri {
+            verificationUri = configuredUri
+        } else {
+            let scheme = req.headers.first(name: "X-Forwarded-Proto")
+                ?? (Constants.TOKEN.isSecure ? "https" : "http")
+            let host = req.headers.first(name: "X-Forwarded-Host")
+                ?? req.headers.first(name: "Host")
+                ?? Constants.PUBLIC_DOMAIN
+            verificationUri = "\(scheme)://\(host)/activate"
+        }
+
+        // Generate device_code (opaque, used by the device to poll)
+        let deviceCode = String.random(length: 32)
+
+        // Generate user_code (short, human-friendly: XXXX-XXXX)
+        let userCodeCharset = String.RandomCharacterSet.custom("ABCDEFGHJKLMNPQRSTUVWXYZ23456789")
+        let userCode = try await generateUniqueUserCode(
+            charset: userCodeCharset,
+            storage: req.application.authCodeStorage
+        )
+
+        // Parse requested scopes
+        let requestedScopes = (deviceRequest.scope ?? "")
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+
+        // Store device session
+        guard let storage = req.application.authCodeStorage else {
+            throw Abort(.insufficientStorage, reason: "ERRORS.CODE_STORAGE_AVAILABILITY")
+        }
+
+        let session = AuthSession.device(DeviceSession(
+            clientId: uitsmijterClient.config.ident.uuidString,
+            deviceCode: Code(value: deviceCode),
+            userCode: userCode,
+            scopes: requestedScopes,
+            payload: nil,
+            status: .pending,
+            ttl: Int64(expiresIn)
+        ))
+        try await storage.set(authSession: session)
+
+        Prometheus.main.deviceFlowInitiation?.inc()
+        Log.info(
+            "Device flow initiated for client \(deviceRequest.client_id), userCode: \(userCode)",
+            requestId: req.id
+        )
+
+        let responseBody = DeviceAuthorizationResponse(
+            device_code: deviceCode,
+            user_code: userCode,
+            verification_uri: verificationUri,
+            expires_in: expiresIn,
+            interval: interval
+        )
+        return try await responseBody.encodeResponse(status: HTTPStatus.ok, for: req).get()
+    }
+
+    // MARK: - Private
+
+    /// Generates a unique XXXX-XXXX user code that is not already in use.
+    private func generateUniqueUserCode(
+        charset: String.RandomCharacterSet,
+        storage: AuthCodeStorage?
+    ) async throws -> String {
+        for _ in 0..<10 {
+            let raw = String.random(length: 8, of: charset)
+            let code = "\(raw.prefix(4))-\(raw.suffix(4))"
+            if await storage?.getDevice(byUserCode: code) == nil {
+                return code
+            }
+        }
+        throw Abort(.internalServerError, reason: "ERRORS.USER_CODE_GENERATION_FAILED")
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
@@ -629,15 +629,14 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
         if clientInfo.mode == .interceptor {
             Log.info("Creating session entry for interceptor login: \(tenant.name)")
             let sessionCode = Code()
-            let interceptorSession = AuthSession(
-                type: .refresh,
+            let interceptorSession = AuthSession.refresh(RefreshSession(
                 state: "interceptor-login",
                 code: sessionCode,
                 scopes: [],
                 payload: payload,
                 redirect: "",
                 ttl: Int64(Constants.COOKIE.EXPIRATION_DAYS * 24 * 60 * 60)
-            )
+            ))
             try? await req.application.authCodeStorage?.set(authSession: interceptorSession)
         }
 

--- a/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
@@ -262,12 +262,16 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
     ///   - form: a filled login form
     /// - Returns: a Provider
     /// - Throws: an error if the provider can't be constructed
-    private func userLoginProvider(for tenant: Tenant, login form: LoginForm) async throws -> JavaScriptProvider {
+    private func userLoginProvider(
+        for tenant: Tenant,
+        login form: LoginForm,
+        grantType: GrantTypes
+    ) async throws -> JavaScriptProvider {
         let providerInterpreter = JavaScriptProvider()
         try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
         try await providerInterpreter.start(
             class: .userLogin,
-            arguments: JSInputCredentials(username: form.username, password: form.password)
+            arguments: JSInputCredentials(username: form.username, password: form.password, grantType: grantType)
         )
         return providerInterpreter
     }
@@ -523,7 +527,19 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
             queryItem: URLQueryItem(name: "loginid", value: loginSession.loginId.uuidString) )
 
         // use a provider to check login requests
-        let providerInterpreter = try await userLoginProvider(for: tenant, login: loginForm)
+        // Grant type is read directly from the submitted form body, not from clientInfo.mode.
+        // clientInfo.mode is unreliable here because the uitsmijter-forward-header middleware
+        // unconditionally injects X-Uitsmijter-Mode: interceptor on the login-proxy ingress,
+        // affecting all requests to that domain including OAuth form submissions.
+        // The form's hidden `mode` field is set by the rendering controller:
+        //   - AuthorizeController renders without an explicit mode → form carries mode=""
+        //   - InterceptorController redirects with mode=interceptor → form carries mode="interceptor"
+        // Reading from the form body bypasses the middleware header and remains correct
+        // even if interceptor flows gain a client association in the future.
+        let modeFromForm = (try? req.content.get(String.self, at: "mode")) ?? ""
+        let loginGrantType: GrantTypes = modeFromForm == LoginMode.interceptor.rawValue
+            ? .interceptor : .authorization_code
+        let providerInterpreter = try await userLoginProvider(for: tenant, login: loginForm, grantType: loginGrantType)
 
         // Ask the provider if the user can login
         if await providerInterpreter.canLogin() == false {

--- a/Sources/Uitsmijter-AuthServer/Controllers/RevokeController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/RevokeController.swift
@@ -360,7 +360,7 @@ struct RevokeController: RouteCollection {
 
         // Look up the refresh token in storage
         guard let session = await authCodeStorage.get(
-            type: .refresh,
+            type: AuthSessionType.refresh,
             codeValue: token
         ), let payload = session.payload else {
             // Token not found or has no payload - might already be revoked or never existed
@@ -384,7 +384,7 @@ struct RevokeController: RouteCollection {
         // Delete the refresh token
         do {
             try await authCodeStorage.delete(
-                type: .refresh,
+                type: AuthSessionType.refresh,
                 codeValue: token
             )
             Log.info(
@@ -395,9 +395,9 @@ struct RevokeController: RouteCollection {
 
             // Cascade: Also revoke the authorization code if it still exists
             // This prevents the client from using the authorization code to get new tokens
-            let authCodeValue = session.code.value
+            let authCodeValue = session.codeValue
             try? await authCodeStorage.delete(
-                type: .code,
+                type: AuthSessionType.code,
                 codeValue: authCodeValue
             )
             Log.debug("Cascaded revocation: authorization code also deleted", requestId: req.id)

--- a/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
@@ -32,6 +32,8 @@ extension TokenController {
             token = try await refreshTokenGrantTypeRequestHandler(for: tenant, on: req)
         case .password:
             token = try await passwordGrantTypeRequestHandler(for: tenant, on: req, scope: scope)
+        case .device_code:
+            token = try await deviceCodeGrantTypeRequestHandler(for: tenant, on: req)
         default:
             throw Abort(.notImplemented, reason: "ERRORS.GRANT_TYPE_NOT_IMPLEMENTED")
         }
@@ -51,11 +53,12 @@ extension TokenController {
         _ authorisationTokenRequest: CodeTokenRequest,
         _ req: Request
     ) throws {
-        // check code challenge if set
-        switch session.code.codeChallengeMethod {
+        // check code challenge if set — only applicable for authorization code sessions
+        guard case .code(let codeSession) = session else { return }
+        switch codeSession.code.codeChallengeMethod {
         case .plain:
             if authorisationTokenRequest.code_challenge_method != nil
-                && authorisationTokenRequest.code_challenge_method != session.code.codeChallengeMethod {
+                && authorisationTokenRequest.code_challenge_method != codeSession.code.codeChallengeMethod {
                 req.requestInfo = RequestInfo(
                     description: "Wrong challenge method (plain). Request: "
                         + """
@@ -64,17 +67,17 @@ extension TokenController {
                                         ?? "_no_code_challenge_method"
                                   ),
                                   """.replacingOccurrences(of: "\n", with: "")
-                        + "Send: \(session.code.codeChallengeMethod?.rawValue ?? "_no_codeChallengeMethod")"
+                        + "Send: \(codeSession.code.codeChallengeMethod?.rawValue ?? "_no_codeChallengeMethod")"
                 )
                 throw Abort(.forbidden, reason: "ERRORS.CODE_CHALLENGE_METHOD_MISMATCH")
             }
 
-            if authorisationTokenRequest.code_verifier != session.code.codeChallenge {
+            if authorisationTokenRequest.code_verifier != codeSession.code.codeChallenge {
                 throw Abort(.forbidden, reason: "ERRORS.CODE_CHALLENGE_METHOD_MISMATCH")
             }
         case .sha256:
             if authorisationTokenRequest.code_challenge_method != nil
-                && authorisationTokenRequest.code_challenge_method != session.code.codeChallengeMethod {
+                && authorisationTokenRequest.code_challenge_method != codeSession.code.codeChallengeMethod {
                 req.requestInfo = RequestInfo(
                     description: "Wrong challenge method (sha256). Request: "
                         + """
@@ -83,7 +86,7 @@ extension TokenController {
                                         ?? "_no_code_challenge_method"
                                   ),
                                   """.replacingOccurrences(of: "\n", with: "")
-                        + "Send: \(session.code.codeChallengeMethod?.rawValue ?? "_no_codeChallengeMethod")"
+                        + "Send: \(codeSession.code.codeChallengeMethod?.rawValue ?? "_no_codeChallengeMethod")"
                 )
                 throw Abort(
                     .forbidden,
@@ -91,7 +94,7 @@ extension TokenController {
                 )
             }
 
-            if authorisationTokenRequest.code_challenge != session.code.codeChallenge {
+            if authorisationTokenRequest.code_challenge != codeSession.code.codeChallenge {
                 throw Abort(.forbidden, reason: "ERRORS.CODE_CHALLENGE_METHOD_MISMATCH")
             }
 
@@ -111,7 +114,7 @@ extension TokenController {
         }
 
         guard let session = await authCodeStorage.get(
-            type: .code,
+            type: AuthSessionType.code,
             codeValue: authorisationTokenRequest.code,
             remove: true
         )
@@ -158,7 +161,7 @@ extension TokenController {
     ) async throws -> TokenResponse {
         let refreshTokenRequest = try req.content.decode(RefreshTokenRequest.self)
         guard let session = await req.application.authCodeStorage?.get(
-            type: .refresh,
+            type: AuthSessionType.refresh,
             codeValue: refreshTokenRequest.refresh_token,
             remove: true
         )
@@ -302,6 +305,93 @@ extension TokenController {
         )
     }
 
+    private func deviceCodeGrantTypeRequestHandler(
+        for tenant: Tenant,
+        on req: Request
+    ) async throws -> TokenResponse {
+        let deviceTokenRequest = try req.content.decode(DeviceTokenRequest.self)
+
+        guard let storage = req.application.authCodeStorage else {
+            throw Abort(.insufficientStorage, reason: "ERRORS.CODE_STORAGE_AVAILABILITY")
+        }
+
+        guard let session = await storage.get(
+            type: AuthSessionType.device,
+            codeValue: deviceTokenRequest.device_code
+        ) else {
+            throw Abort(.badRequest, reason: "ERRORS.INVALID_GRANT")
+        }
+
+        guard case .device(let deviceData) = session else {
+            throw Abort(.badRequest, reason: "ERRORS.INVALID_GRANT")
+        }
+
+        // Rate limiting: check if polling too fast
+        let client = await Client.find(
+            in: req.application.entityStorage,
+            clientId: deviceData.clientId
+        )
+        let pollInterval = Double(client?.config.device_grant_config?.interval ?? 5)
+        if let lastPolled = deviceData.lastPolledAt, Date().timeIntervalSince(lastPolled) < pollInterval {
+            try await storage.updateDevice(
+                deviceCode: deviceTokenRequest.device_code,
+                newStatus: deviceData.status,
+                payload: deviceData.payload,
+                lastPolledAt: Date()
+            )
+            throw Abort(.tooManyRequests, reason: "ERRORS.SLOW_DOWN")
+        }
+
+        // Update lastPolledAt
+        try await storage.updateDevice(
+            deviceCode: deviceTokenRequest.device_code,
+            newStatus: deviceData.status,
+            payload: deviceData.payload,
+            lastPolledAt: Date()
+        )
+
+        switch deviceData.status {
+        case .denied:
+            try await storage.delete(type: AuthSessionType.device, codeValue: deviceTokenRequest.device_code)
+            throw Abort(.badRequest, reason: "ERRORS.ACCESS_DENIED")
+
+        case .pending:
+            Prometheus.main.deviceFlowPending?.inc()
+            throw Abort(.badRequest, reason: "ERRORS.AUTHORIZATION_PENDING")
+
+        case .authorized:
+            try await storage.delete(type: AuthSessionType.device, codeValue: deviceTokenRequest.device_code)
+
+            guard deviceData.payload != nil else {
+                throw Abort(.internalServerError, reason: "ERRORS.EXPECTED_VALUE_UNSET")
+            }
+
+            let userScopes: String
+            if let payloadScope = deviceData.payload?.scope, !payloadScope.isEmpty {
+                userScopes = payloadScope
+            } else {
+                userScopes = deviceData.scopes.sorted().joined(separator: " ")
+            }
+
+            let (accessToken, refreshToken) = try await getNewTokenPair(
+                on: req,
+                tenant: tenant,
+                session: session,
+                scopes: userScopes.components(separatedBy: " ")
+            )
+
+            Prometheus.main.deviceFlowSuccess?.inc()
+
+            return TokenResponse(
+                access_token: accessToken.value,
+                token_type: .Bearer,
+                expires_in: accessToken.secondsToExpire,
+                refresh_token: refreshToken.value,
+                scope: userScopes
+            )
+        }
+    }
+
     func getNewTokenPair(
         on req: Request,
         tenant: Tenant,
@@ -342,15 +432,14 @@ extension TokenController {
         )
         let refreshToken: Code = Code()
 
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: session.state,
             code: refreshToken,
             scopes: scopes,
             payload: session.payload,
             redirect: session.redirect,
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
         try await req.application.authCodeStorage?.set(authSession: refreshSession)
 
         // Trigger status update for Kubernetes tenant and client after creating refresh token

--- a/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
@@ -218,7 +218,8 @@ extension TokenController {
             class: .userLogin,
             arguments: JSInputCredentials(
                 username: passwordTokenRequest.username,
-                password: passwordTokenRequest.password
+                password: passwordTokenRequest.password,
+                grantType: .password
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Entities/Client/Client.swift
+++ b/Sources/Uitsmijter-AuthServer/Entities/Client/Client.swift
@@ -83,6 +83,19 @@ struct Client: ClientProtocol, Sendable {
     }
 }
 
+/// Configuration for the Device Authorization Grant (RFC 8628).
+///
+/// When present and `device_code` is listed in `grant_types`, enables the
+/// device authorization flow for input-constrained devices (CLIs, smart TVs, IoT).
+struct DeviceGrantConfig: Codable, Sendable {
+    /// The lifetime in seconds of the `device_code` and `user_code`. Defaults to 1800.
+    var expires_in: Int?
+    /// Minimum polling interval in seconds. Defaults to 5.
+    var interval: Int?
+    /// Override the verification URI shown to the user. Auto-detected from the request if nil.
+    var verification_uri: String?
+}
+
 /// Complete configuration specification for an OAuth2 client.
 ///
 /// Contains all settings required for OAuth2 authorization flows, including
@@ -172,6 +185,12 @@ struct ClientSpec: Codable, Sendable {
     /// Recommended for: SPAs, mobile apps, and any public client.
     var isPkceOnly: Bool? = false
 
+    /// Device Authorization Grant configuration (RFC 8628).
+    ///
+    /// When present, the `device_code` grant type may be used by this client.
+    /// Requires `device_code` to also be listed in `grant_types`.
+    var device_grant_config: DeviceGrantConfig?
+
     /// Initialize a client specification.
     ///
     /// - Parameters:
@@ -192,7 +211,8 @@ struct ClientSpec: Codable, Sendable {
         allowedProviderScopes: [String]? = nil,
         referrers: [String]? = nil,
         secret: String? = nil,
-        isPkceOnly: Bool? = false
+        isPkceOnly: Bool? = false,
+        device_grant_config: DeviceGrantConfig? = nil
     ) {
         self.ident = ident
         self.tenantname = tenantname
@@ -203,6 +223,7 @@ struct ClientSpec: Codable, Sendable {
         self.referrers = referrers
         self.secret = secret
         self.isPkceOnly = isPkceOnly
+        self.device_grant_config = device_grant_config
     }
 }
 

--- a/Sources/Uitsmijter-AuthServer/Http/RequestClientMiddleware.swift
+++ b/Sources/Uitsmijter-AuthServer/Http/RequestClientMiddleware.swift
@@ -108,7 +108,8 @@ final class RequestClientMiddleware: AsyncMiddleware {
         Log.info("Login Mode: \(loginMode.rawValue) to: \(request.url.string)", requestId: request.id)
 
         // token request does not need further checks and do not have a clientInfo, yet
-        if ["/token", "/token/info"].contains(request.url.string) {
+        if ["/token", "/token/info", "/oauth/device_authorization", "/activate"].contains(request.url.string)
+            || request.url.string.hasPrefix("/activate?") {
             return try await next.respond(to: request)
         }
 

--- a/Sources/Uitsmijter-AuthServer/Monitoring/Prometheus.swift
+++ b/Sources/Uitsmijter-AuthServer/Monitoring/Prometheus.swift
@@ -67,6 +67,18 @@ struct Prometheus: Sendable {
     /// Currently known clients
     let countClients: PromGauge<Int>?
 
+    // MARK: - Device Authorization Grant (RFC 8628)
+
+    /// How many device authorization flows were initiated
+    let deviceFlowInitiation: PromCounter<Int>?
+    /// How many device authorization flows were successfully authorized by the user
+    let deviceFlowAuthorized: PromCounter<Int>?
+    /// How many device token polls returned authorization_pending
+    let deviceFlowPending: PromCounter<Int>?
+    /// How many device authorization flows were completed with an access token issued
+    let deviceFlowSuccess: PromCounter<Int>?
+
+    // swiftlint:disable function_body_length
     /// Private init to initialize the singleton once
     private init() {
         MetricsSystem.bootstrap(PrometheusMetricsFactory(client: Prometheus.prometheusClient))
@@ -148,7 +160,29 @@ struct Prometheus: Sendable {
             named: "\(Prometheus.metricsPrefix)_clients_count",
             helpText: "Current number of managed clients for all tenants."
         )
+
+        self.deviceFlowInitiation = client.createCounter(
+            forType: Int.self,
+            named: "\(Prometheus.metricsPrefix)_device_flow_initiation",
+            helpText: "Counter of device authorization flows initiated (POST /oauth/device_authorization)."
+        )
+        self.deviceFlowAuthorized = client.createCounter(
+            forType: Int.self,
+            named: "\(Prometheus.metricsPrefix)_device_flow_authorized",
+            helpText: "Counter of device flows authorized by the user at the activation endpoint."
+        )
+        self.deviceFlowPending = client.createCounter(
+            forType: Int.self,
+            named: "\(Prometheus.metricsPrefix)_device_flow_pending",
+            helpText: "Counter of device token poll responses with authorization_pending."
+        )
+        self.deviceFlowSuccess = client.createCounter(
+            forType: Int.self,
+            named: "\(Prometheus.metricsPrefix)_device_flow_success",
+            helpText: "Counter of device flows completed with an access token issued."
+        )
     }
+    // swiftlint:enable function_body_length
 
     /// Return the global prometheus client
     ///

--- a/Sources/Uitsmijter-AuthServer/OAuth/DeviceAuthorizationRequest.swift
+++ b/Sources/Uitsmijter-AuthServer/OAuth/DeviceAuthorizationRequest.swift
@@ -1,0 +1,19 @@
+import Foundation
+import Vapor
+
+/// Request body for the Device Authorization endpoint (RFC 8628, Section 3.1).
+///
+/// The device posts this to `POST /oauth/device_authorization` to initiate a device flow.
+///
+/// ## Example
+///
+/// ```
+/// POST /oauth/device_authorization
+/// Content-Type: application/x-www-form-urlencoded
+///
+/// client_id=9095A4F2-35B2-48B1-A325-309CA324B97E&scope=openid+profile
+/// ```
+struct DeviceAuthorizationRequest: Content, ClientIdProtocol, Sendable {
+    var client_id: String
+    var scope: String?
+}

--- a/Sources/Uitsmijter-AuthServer/OAuth/DeviceAuthorizationResponse.swift
+++ b/Sources/Uitsmijter-AuthServer/OAuth/DeviceAuthorizationResponse.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Vapor
+
+// swiftlint:disable:next type_name
+/// Response from the Device Authorization endpoint (RFC 8628, Section 3.2).
+///
+/// ## Example Response
+///
+/// ```json
+/// {
+///   "device_code": "GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS",
+///   "user_code": "WDJB-MJHT",
+///   "verification_uri": "https://example.com/activate",
+///   "expires_in": 1800,
+///   "interval": 5
+/// }
+/// ```
+struct DeviceAuthorizationResponse: Content, Sendable {
+    /// The device verification code, used by the device to poll the token endpoint.
+    let device_code: String
+
+    /// The end-user verification code shown on the device screen.
+    let user_code: String
+
+    /// The end-user verification URI on the authorization server.
+    let verification_uri: String
+
+    /// The lifetime in seconds of the `device_code` and `user_code`.
+    let expires_in: Int
+
+    /// The minimum amount of time in seconds that the client should wait between polling requests.
+    let interval: Int
+}

--- a/Sources/Uitsmijter-AuthServer/OAuth/DeviceTokenRequest.swift
+++ b/Sources/Uitsmijter-AuthServer/OAuth/DeviceTokenRequest.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Vapor
+
+/// Token request for the Device Authorization Grant (RFC 8628, Section 3.4).
+///
+/// The device posts this to `POST /token` to poll for an access token after
+/// the user has authorized the device at the activation endpoint.
+///
+/// ## Polling Behavior
+///
+/// The device polls at the interval returned by the device authorization response
+/// (default: 5 seconds). The server responds with one of:
+/// - `200 OK` with tokens once the user has authorized
+/// - `400 authorization_pending` while the user hasn't completed authorization yet
+/// - `400 slow_down` if polling too frequently (device must increase interval)
+/// - `400 access_denied` if the user denied authorization
+///
+/// ## Example
+///
+/// ```
+/// POST /token
+/// Content-Type: application/x-www-form-urlencoded
+///
+/// grant_type=device_code
+///   &device_code=GmRhmhcxhwAzkoEqiMEg_DnyEysNkuNhszIySk9eS
+///   &client_id=9095A4F2-35B2-48B1-A325-309CA324B97E
+/// ```
+struct DeviceTokenRequest: TokenRequestProtocol, Sendable {
+
+    /// The grant type. Must be `device_code`.
+    var grant_type: GrantTypes
+
+    /// The client identifier.
+    var client_id: String
+
+    /// The client secret for confidential clients.
+    var client_secret: String?
+
+    /// The device verification code obtained from the device authorization response.
+    let device_code: String
+}

--- a/Sources/Uitsmijter-AuthServer/OAuth/GrantTypes.swift
+++ b/Sources/Uitsmijter-AuthServer/OAuth/GrantTypes.swift
@@ -34,4 +34,8 @@ enum GrantTypes: String, Codable, Sendable {
     /// A special grant type that Uitsmijter supports for an authentication middleware that passes the user to
     /// a backend system if the login succeeds.
     case interceptor
+
+    /// The Device Authorization Grant (RFC 8628) for input-constrained devices (CLIs, smart TVs, IoT) that
+    /// cannot open a browser directly. The device polls the token endpoint while the user authorizes on another device.
+    case device_code
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
@@ -7,4 +7,12 @@ struct JSInputCredentials: JSInputParameterProtocol, Sendable {
     let username: String
     /// Users password
     let password: String
+    /// The OAuth2 grant type used for this authentication request
+    let grantType: GrantTypes
+
+    enum CodingKeys: String, CodingKey {
+        case username
+        case password
+        case grantType = "grant_type"
+    }
 }

--- a/Sources/Uitsmijter-AuthServer/Session/AuthSession+Redirect.swift
+++ b/Sources/Uitsmijter-AuthServer/Session/AuthSession+Redirect.swift
@@ -11,6 +11,6 @@ extension AuthSession {
     /// - Returns: A redirection response
     ///
     func codeRedirect(to req: Request) -> Response {
-        req.redirect(to: "\(redirect)?code=\(code.value)&state=\(state)")
+        req.redirect(to: "\(redirect)?code=\(codeValue)&state=\(state)")
     }
 }

--- a/Sources/Uitsmijter-AuthServer/Session/AuthSession.swift
+++ b/Sources/Uitsmijter-AuthServer/Session/AuthSession.swift
@@ -1,137 +1,38 @@
 import Foundation
 
-/// Session state for OAuth2 authorization code flow.
-///
-/// `AuthSession` stores the intermediate state during an OAuth2 authorization flow,
-/// bridging the gap between user authorization and token exchange. This session
-/// contains the authorization code, state parameter, and user payload that will
-/// be used to generate access tokens.
-///
-/// ## OAuth2 Authorization Code Flow
-///
-/// 1. Client initiates authorization request with `state` parameter
-/// 2. User authenticates and authorizes the client
-/// 3. `AuthSession` is created with authorization `code` and user `payload`
-/// 4. Session is stored temporarily (with TTL)
-/// 5. Client exchanges code for access token at token endpoint
-/// 6. Session is consumed and removed
-///
-/// ## Session Types
-///
-/// Auth sessions can represent different OAuth2 flows:
-/// - ``CodeType/code``: Standard authorization code
-/// - ``CodeType/refresh``: Refresh token flow
-///
-/// ## Example
-///
-/// ```swift
-/// let session = AuthSession(
-///     type: .code,
-///     state: "xyz123",
-///     code: Code(),
-///     scopes: ["openid", "profile"],
-///     payload: userPayload,
-///     redirect: "https://app.example.com/callback",
-///     ttl: 300  // 5 minutes
-/// )
-/// ```
-///
-/// ## Security Considerations
-///
-/// - Authorization codes are single-use and expire quickly (typically 5-10 minutes)
-/// - The `state` parameter prevents CSRF attacks (RFC 6749, Section 10.12)
-/// - Sessions are stored securely in Redis or memory
-/// - Codes should be cryptographically random
-///
-/// - SeeAlso: ``Code``, ``Payload``, ``TimeToLiveProtocol``
-struct AuthSession: Codable, TimeToLiveProtocol, Sendable {
-    /// The type of authorization code.
-    ///
-    /// Distinguishes between standard authorization codes and refresh tokens.
-    enum CodeType: String, Codable, Sendable {
-        /// Standard authorization code from authorization endpoint.
-        case code
+// MARK: - Supporting Types
 
-        /// Refresh token used to obtain new access tokens.
-        case refresh
-    }
+/// Status of a device authorization flow (RFC 8628)
+enum DeviceGrantStatus: String, Codable, Sendable {
+    case pending, authorized, denied
+}
 
-    /// The type of this authorization session.
-    ///
-    /// Specifies whether this is a standard authorization code or refresh token session.
-    let type: AuthSession.CodeType
+/// Discriminator for ``AuthSession`` cases and storage key prefix.
+enum AuthSessionType: String, Sendable, Equatable {
+    case code, refresh, device
+}
 
-    /// The state parameter from the client's authorization request.
-    ///
-    /// This opaque value is returned unchanged to the client to prevent CSRF attacks.
-    /// The client should verify this matches their original request.
-    ///
-    /// Per OAuth 2.0 (RFC 6749, Section 10.12), the state parameter is recommended
-    /// for preventing cross-site request forgery.
+// MARK: - Per-type session structs
+
+/// Session for the standard OAuth 2.0 authorization code flow.
+struct CodeSession: Codable, Sendable {
     let state: String
-
-    /// The authorization code generated for this session.
-    ///
-    /// This one-time code is exchanged for an access token at the token endpoint.
-    /// The code is cryptographically random and expires quickly (typically 5-10 minutes).
-    ///
-    /// - SeeAlso: ``Code``
     let code: Code
-
-    /// The OAuth2 scopes approved for this authorization.
-    ///
-    /// Contains the intersection of:
-    /// - Scopes requested by the client
-    /// - Scopes allowed for the client
-    /// - Scopes authorized by the user
-    ///
-    /// These scopes determine the permissions granted to the resulting access token.
     let scopes: [String]
-
-    /// The authenticated user's payload.
-    ///
-    /// Contains user information retrieved from the authentication provider.
-    /// This payload is used to populate claims in the issued JWT access token.
-    ///
-    /// - SeeAlso: ``Payload``
     let payload: Payload?
-
-    /// The redirect URI where the authorization response will be sent.
-    ///
-    /// This URI must match one of the client's registered redirect URIs.
-    /// After authorization, the authorization code is sent to this URI.
     let redirect: String
-
-    /// Time-to-live for this session in seconds.
-    ///
-    /// Authorization codes should have short lifetimes (typically 300-600 seconds).
-    /// After expiration, the session is automatically removed from storage.
-    ///
-    /// Per OAuth 2.0 (RFC 6749, Section 4.1.2), authorization codes should be
-    /// short-lived and single-use.
     var ttl: Int64?
+    var generated: Date
 
-    /// The timestamp when this session was created.
-    ///
-    /// Used for session expiration calculations and auditing.
-    var generated: Date = Date()
-
-    /// Initialize an authorization session.
-    ///
-    /// - Parameters:
-    ///   - type: The type of authorization code (code or refresh)
-    ///   - state: The state parameter from the authorization request
-    ///   - code: The generated authorization code
-    ///   - scopes: The approved OAuth2 scopes
-    ///   - payload: The authenticated user's payload
-    ///   - redirect: The redirect URI for the authorization response
-    ///   - ttl: Optional time-to-live in seconds (defaults to system configuration)
-    ///   - generated: The session creation timestamp (defaults to now)
     init(
-        type: AuthSession.CodeType, state: String, code: Code, scopes: [String],
-        payload: Payload?, redirect: String, ttl: Int64? = nil, generated: Date = Date()
+        state: String,
+        code: Code,
+        scopes: [String],
+        payload: Payload?,
+        redirect: String,
+        ttl: Int64? = nil,
+        generated: Date = Date()
     ) {
-        self.type = type
         self.state = state
         self.code = code
         self.scopes = scopes
@@ -140,5 +41,254 @@ struct AuthSession: Codable, TimeToLiveProtocol, Sendable {
         self.ttl = ttl
         self.generated = generated
     }
+}
 
+/// Session for the OAuth 2.0 refresh token flow.
+struct RefreshSession: Codable, Sendable {
+    let state: String
+    let code: Code
+    let scopes: [String]
+    let payload: Payload?
+    let redirect: String
+    var ttl: Int64?
+    var generated: Date
+
+    init(
+        state: String,
+        code: Code,
+        scopes: [String],
+        payload: Payload?,
+        redirect: String,
+        ttl: Int64? = nil,
+        generated: Date = Date()
+    ) {
+        self.state = state
+        self.code = code
+        self.scopes = scopes
+        self.payload = payload
+        self.redirect = redirect
+        self.ttl = ttl
+        self.generated = generated
+    }
+}
+
+/// Session for the OAuth 2.0 Device Authorization Grant (RFC 8628).
+struct DeviceSession: Codable, Sendable {
+    let clientId: String
+    let deviceCode: Code
+    let userCode: String
+    let scopes: [String]
+    var payload: Payload?
+    var status: DeviceGrantStatus
+    var lastPolledAt: Date?
+    var ttl: Int64?
+    var generated: Date
+
+    init(
+        clientId: String,
+        deviceCode: Code,
+        userCode: String,
+        scopes: [String],
+        payload: Payload? = nil,
+        status: DeviceGrantStatus = .pending,
+        lastPolledAt: Date? = nil,
+        ttl: Int64? = nil,
+        generated: Date = Date()
+    ) {
+        self.clientId = clientId
+        self.deviceCode = deviceCode
+        self.userCode = userCode
+        self.scopes = scopes
+        self.payload = payload
+        self.status = status
+        self.lastPolledAt = lastPolledAt
+        self.ttl = ttl
+        self.generated = generated
+    }
+}
+
+// MARK: - Discriminated Union
+
+/// Session state for OAuth2 authorization flows.
+///
+/// `AuthSession` is a discriminated union covering the standard authorization code flow,
+/// refresh token flow, and the Device Authorization Grant (RFC 8628). The union is stored
+/// and retrieved by ``AuthCodeStorageProtocol`` implementations.
+///
+/// ## Backward Compatibility
+///
+/// The JSON encoding uses `"type": "code"` / `"type": "refresh"` / `"type": "device"` as
+/// the discriminator. Existing Redis sessions encoded with the old flat-struct format decode
+/// correctly because they already carry `"type": "code"` or `"type": "refresh"`.
+///
+/// - SeeAlso: ``CodeSession``, ``RefreshSession``, ``DeviceSession``
+enum AuthSession: Codable, TimeToLiveProtocol, Sendable {
+    case code(CodeSession)
+    case refresh(RefreshSession)
+    case device(DeviceSession)
+
+    // MARK: - Forwarding computed properties
+
+    /// The session type discriminator.
+    var sessionType: AuthSessionType {
+        switch self {
+        case .code:    return .code
+        case .refresh: return .refresh
+        case .device:  return .device
+        }
+    }
+
+    /// The primary storage lookup key value.
+    var codeValue: String {
+        switch self {
+        case .code(let sess):    return sess.code.value
+        case .refresh(let sess): return sess.code.value
+        case .device(let sess):  return sess.deviceCode.value
+        }
+    }
+
+    /// The authenticated user's payload, or `nil` for pending device sessions.
+    var payload: Payload? {
+        switch self {
+        case .code(let sess):    return sess.payload
+        case .refresh(let sess): return sess.payload
+        case .device(let sess):  return sess.payload
+        }
+    }
+
+    /// The OAuth2 scopes approved for this session.
+    var scopes: [String] {
+        switch self {
+        case .code(let sess):    return sess.scopes
+        case .refresh(let sess): return sess.scopes
+        case .device(let sess):  return sess.scopes
+        }
+    }
+
+    /// The CSRF state parameter (empty for device sessions, which have no redirect).
+    var state: String {
+        switch self {
+        case .code(let sess):    return sess.state
+        case .refresh(let sess): return sess.state
+        case .device:            return ""
+        }
+    }
+
+    /// The redirect URI (empty for device sessions, which have no redirect).
+    var redirect: String {
+        switch self {
+        case .code(let sess):    return sess.redirect
+        case .refresh(let sess): return sess.redirect
+        case .device:            return ""
+        }
+    }
+
+    // MARK: - TimeToLiveProtocol
+
+    var ttl: Int64? {
+        switch self {
+        case .code(let sess):    return sess.ttl
+        case .refresh(let sess): return sess.ttl
+        case .device(let sess):  return sess.ttl
+        }
+    }
+
+    var generated: Date {
+        switch self {
+        case .code(let sess):    return sess.generated
+        case .refresh(let sess): return sess.generated
+        case .device(let sess):  return sess.generated
+        }
+    }
+
+    // MARK: - Custom Codable (discriminator key: "type")
+
+    private enum CodingKeys: String, CodingKey {
+        // discriminator
+        case type
+        // code / refresh fields
+        case state, code, scopes, payload, redirect, ttl, generated
+        // device-only fields
+        case clientId, deviceCode, userCode, status, lastPolledAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeName = try container.decode(String.self, forKey: .type)
+        switch typeName {
+        case AuthSessionType.code.rawValue:
+            self = .code(CodeSession(
+                state: try container.decode(String.self, forKey: .state),
+                code: try container.decode(Code.self, forKey: .code),
+                scopes: try container.decode([String].self, forKey: .scopes),
+                payload: try container.decodeIfPresent(Payload.self, forKey: .payload),
+                redirect: try container.decode(String.self, forKey: .redirect),
+                ttl: try container.decodeIfPresent(Int64.self, forKey: .ttl),
+                generated: try container.decodeIfPresent(Date.self, forKey: .generated) ?? Date()
+            ))
+        case AuthSessionType.refresh.rawValue:
+            self = .refresh(RefreshSession(
+                state: try container.decode(String.self, forKey: .state),
+                code: try container.decode(Code.self, forKey: .code),
+                scopes: try container.decode([String].self, forKey: .scopes),
+                payload: try container.decodeIfPresent(Payload.self, forKey: .payload),
+                redirect: try container.decode(String.self, forKey: .redirect),
+                ttl: try container.decodeIfPresent(Int64.self, forKey: .ttl),
+                generated: try container.decodeIfPresent(Date.self, forKey: .generated) ?? Date()
+            ))
+        case AuthSessionType.device.rawValue:
+            self = .device(DeviceSession(
+                clientId: try container.decode(String.self, forKey: .clientId),
+                deviceCode: try container.decode(Code.self, forKey: .deviceCode),
+                userCode: try container.decode(String.self, forKey: .userCode),
+                scopes: try container.decode([String].self, forKey: .scopes),
+                payload: try container.decodeIfPresent(Payload.self, forKey: .payload),
+                status: try container.decode(DeviceGrantStatus.self, forKey: .status),
+                lastPolledAt: try container.decodeIfPresent(Date.self, forKey: .lastPolledAt),
+                ttl: try container.decodeIfPresent(Int64.self, forKey: .ttl),
+                generated: try container.decodeIfPresent(Date.self, forKey: .generated) ?? Date()
+            ))
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unknown AuthSession type: \(typeName)"
+            )
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .code(let session):
+            try container.encode(AuthSessionType.code.rawValue, forKey: .type)
+            try container.encode(session.state, forKey: .state)
+            try container.encode(session.code, forKey: .code)
+            try container.encode(session.scopes, forKey: .scopes)
+            try container.encodeIfPresent(session.payload, forKey: .payload)
+            try container.encode(session.redirect, forKey: .redirect)
+            try container.encodeIfPresent(session.ttl, forKey: .ttl)
+            try container.encode(session.generated, forKey: .generated)
+        case .refresh(let session):
+            try container.encode(AuthSessionType.refresh.rawValue, forKey: .type)
+            try container.encode(session.state, forKey: .state)
+            try container.encode(session.code, forKey: .code)
+            try container.encode(session.scopes, forKey: .scopes)
+            try container.encodeIfPresent(session.payload, forKey: .payload)
+            try container.encode(session.redirect, forKey: .redirect)
+            try container.encodeIfPresent(session.ttl, forKey: .ttl)
+            try container.encode(session.generated, forKey: .generated)
+        case .device(let session):
+            try container.encode(AuthSessionType.device.rawValue, forKey: .type)
+            try container.encode(session.clientId, forKey: .clientId)
+            try container.encode(session.deviceCode, forKey: .deviceCode)
+            try container.encode(session.userCode, forKey: .userCode)
+            try container.encode(session.scopes, forKey: .scopes)
+            try container.encodeIfPresent(session.payload, forKey: .payload)
+            try container.encode(session.status, forKey: .status)
+            try container.encodeIfPresent(session.lastPolledAt, forKey: .lastPolledAt)
+            try container.encodeIfPresent(session.ttl, forKey: .ttl)
+            try container.encode(session.generated, forKey: .generated)
+        }
+    }
 }

--- a/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfiguration.swift
+++ b/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfiguration.swift
@@ -402,6 +402,15 @@ struct OpenidConfiguration: Codable, Sendable {
     /// ```
     let code_challenge_methods_supported: [String]?
 
+    /// OPTIONAL. URL of the authorization server's device authorization endpoint (RFC 8628).
+    ///
+    /// ## Example
+    ///
+    /// ```
+    /// "https://auth.example.com/oauth/device_authorization"
+    /// ```
+    let device_authorization_endpoint: String?
+
     // MARK: - Initialization
 
     /// Initialize OpenID Configuration with all fields.
@@ -483,7 +492,8 @@ struct OpenidConfiguration: Codable, Sendable {
         request_object_signing_alg_values_supported: [String]? = nil,
         request_object_encryption_alg_values_supported: [String]? = nil,
         request_object_encryption_enc_values_supported: [String]? = nil,
-        code_challenge_methods_supported: [String]? = nil
+        code_challenge_methods_supported: [String]? = nil,
+        device_authorization_endpoint: String? = nil
     ) {
         self.issuer = issuer
         self.authorization_endpoint = authorization_endpoint
@@ -523,6 +533,7 @@ struct OpenidConfiguration: Codable, Sendable {
         self.request_object_encryption_alg_values_supported = request_object_encryption_alg_values_supported
         self.request_object_encryption_enc_values_supported = request_object_encryption_enc_values_supported
         self.code_challenge_methods_supported = code_challenge_methods_supported
+        self.device_authorization_endpoint = device_authorization_endpoint
     }
 }
 // swiftlint:enable identifier_name

--- a/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfigurationBuilder.swift
+++ b/Sources/Uitsmijter-AuthServer/WellKnown/OpenidConfigurationBuilder.swift
@@ -175,6 +175,14 @@ actor OpenidConfigurationBuilder {
         let endSessionEndpoint = "\(issuer)/logout"
         let revocationEndpoint = "\(issuer)/revoke"
 
+        // Device authorization endpoint (RFC 8628) — advertise when any client supports device_code
+        let hasDeviceGrantClient = tenantClients.contains { client in
+            client.config.grant_types?.contains(GrantTypes.device_code.rawValue) == true
+        }
+        let deviceAuthorizationEndpoint = hasDeviceGrantClient
+            ? "\(issuer)/oauth/device_authorization"
+            : nil
+
         // Get policy URLs from tenant information
         let policyUri = tenant.config.informations?.privacy_url
         let imprintUri = tenant.config.informations?.imprint_url
@@ -220,7 +228,8 @@ actor OpenidConfigurationBuilder {
             request_object_signing_alg_values_supported: nil,
             request_object_encryption_alg_values_supported: nil,
             request_object_encryption_enc_values_supported: nil,
-            code_challenge_methods_supported: codeChallengeMethods
+            code_challenge_methods_supported: codeChallengeMethods,
+            device_authorization_endpoint: deviceAuthorizationEndpoint
         )
     }
 

--- a/Sources/Uitsmijter-AuthServer/routes.swift
+++ b/Sources/Uitsmijter-AuthServer/routes.swift
@@ -40,4 +40,8 @@ func routes(_ app: Application) throws {
     try app.register(collection: AuthorizeController())
     try app.register(collection: TokenController())
     try app.register(collection: RevokeController())
+
+    // Device Authorization Grant (RFC 8628)
+    try app.register(collection: DeviceController())
+    try app.register(collection: ActivateController())
 }

--- a/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeMemoryStorageGarbageCollectionTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeMemoryStorageGarbageCollectionTest.swift
@@ -9,31 +9,30 @@ import VaporTesting
     @Test func storeSessionsInMemoryGarbageCollection() async throws {
         let storage = MemoryAuthCodeStorage()
 
-        let session_1 = AuthSession(
-            type: .code,
+        let session_1 = AuthSession.code(CodeSession(
             state: "state_1",
             code: Code(value: "code_1"),
             scopes: [],
             payload: nil,
-            redirect: "", ttl: 2
-        )
-        let session_2 = AuthSession(
-            type: .code,
+            redirect: "",
+            ttl: 2
+        ))
+        let session_2 = AuthSession.code(CodeSession(
             state: "state_2",
             code: Code(value: "code_2"),
             scopes: [],
             payload: nil,
-            redirect: "", ttl: 4
-        )
-        let session_3 = AuthSession(
-            type: .code,
+            redirect: "",
+            ttl: 4
+        ))
+        let session_3 = AuthSession.code(CodeSession(
             state: "state_3",
             code: Code(value: "code_3"),
             scopes: [],
             payload: nil,
             redirect: "",
             ttl: 6
-        )
+        ))
 
         do {
             try await storage.set(authSession: session_1)

--- a/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeStorageTest+Memory.swift
+++ b/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeStorageTest+Memory.swift
@@ -8,33 +8,30 @@ import VaporTesting
     func setupStorage() async throws -> AuthCodeStorage {
         let storage = AuthCodeStorage(use: .memory)
 
-        let session_1 = AuthSession(
-            type: .code,
+        let session_1 = AuthSession.code(CodeSession(
             state: "state_1",
             code: Code(value: "code_1"),
             scopes: ["foo", "bar"],
             payload: nil,
             redirect: "",
             ttl: 10
-        )
-        let session_2 = AuthSession(
-            type: .code,
+        ))
+        let session_2 = AuthSession.code(CodeSession(
             state: "state_2",
             code: Code(value: "code_2"),
             scopes: ["foo", "bar"],
             payload: nil,
             redirect: "",
             ttl: 50
-        )
-        let session_TTL = AuthSession(
-            type: .code,
+        ))
+        let session_TTL = AuthSession.code(CodeSession(
             state: "state_TTL",
             code: Code(value: "code_TTL"),
             scopes: [],
             payload: nil,
             redirect: "",
             ttl: 1
-        )
+        ))
         do {
             try await storage.set(authSession: session_1)
             try await storage.set(authSession: session_2)
@@ -62,7 +59,7 @@ import VaporTesting
         #expect(ret_set_twice != nil)
 
         #expect(ret_set?.state == "state_1")
-        #expect(ret_set?.code.value == "code_1")
+        #expect(ret_set?.codeValue == "code_1")
     }
 
     @Test func storeSessionsInMemoryGetRemoved() async throws {
@@ -74,7 +71,7 @@ import VaporTesting
         #expect(ret_set_twice == nil)
 
         #expect(ret_set?.state == "state_1")
-        #expect(ret_set?.code.value == "code_1")
+        #expect(ret_set?.codeValue == "code_1")
     }
 
     @Test func storeSessionsInMemoryTTL() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeStorageTest+RedisMock.swift
+++ b/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/AuthCodeStorageTest+RedisMock.swift
@@ -67,33 +67,30 @@ import Redis
         let mock = RedisMock()
         let storage = AuthCodeStorage(use: .redis(client: mock))
 
-        let session_1 = AuthSession(
-            type: .code,
+        let session_1 = AuthSession.code(CodeSession(
             state: "state_1",
             code: Code(value: "code_1"),
             scopes: ["foo", "bar"],
             payload: nil,
             redirect: "",
             ttl: 10
-        )
-        let session_2 = AuthSession(
-            type: .code,
+        ))
+        let session_2 = AuthSession.code(CodeSession(
             state: "state_2",
             code: Code(value: "code_2"),
             scopes: ["foo", "bar"],
             payload: nil,
             redirect: "",
             ttl: 50
-        )
-        let session_TTL = AuthSession(
-            type: .code,
+        ))
+        let session_TTL = AuthSession.code(CodeSession(
             state: "state_TTL",
             code: Code(value: "code_TTL"),
             scopes: [],
             payload: nil,
             redirect: "",
             ttl: 1
-        )
+        ))
 
         do {
             try await storage.set(authSession: session_1)
@@ -123,15 +120,14 @@ import Redis
         let mock = RedisMock()
         let storage = AuthCodeStorage(use: .redis(client: mock))
 
-        let session_1 = AuthSession(
-            type: .code,
+        let session_1 = AuthSession.code(CodeSession(
             state: "state_1",
             code: Code(value: "code_1"),
             scopes: ["foo", "bar"],
             payload: nil,
             redirect: "",
             ttl: 10
-        )
+        ))
         try await storage.set(authSession: session_1)
 
         _ = await storage.get(type: .code, codeValue: "code_1", remove: true)

--- a/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/DeviceStorageTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/AuthCodeStorage/DeviceStorageTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import Uitsmijter_AuthServer
+
+@Suite("Device Storage Tests")
+struct DeviceStorageTests {
+
+    private func makeDeviceSession(
+        clientId: String = "test-client-001",
+        deviceCode: String = "dev-code-0001",
+        userCode: String = "ABCD-EFGH",
+        status: DeviceGrantStatus = .pending
+    ) -> AuthSession {
+        AuthSession.device(DeviceSession(
+            clientId: clientId,
+            deviceCode: Code(value: deviceCode),
+            userCode: userCode,
+            scopes: ["read"],
+            payload: nil,
+            status: status
+        ))
+    }
+
+    // MARK: - getDevice(byUserCode:)
+
+    @Test("getDevice returns session for known user code")
+    func getDeviceByKnownUserCode() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        let found = await storage.getDevice(byUserCode: "ABCD-EFGH")
+        #expect(found != nil)
+        #expect(found?.codeValue == "dev-code-0001")
+    }
+
+    @Test("getDevice returns nil for unknown user code")
+    func getDeviceByUnknownUserCode() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        let notFound = await storage.getDevice(byUserCode: "ZZZZ-ZZZZ")
+        #expect(notFound == nil)
+    }
+
+    @Test("getDevice is case-sensitive for user code")
+    func getDeviceCaseSensitiveUserCode() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession(userCode: "ABCD-EFGH"))
+
+        let notFound = await storage.getDevice(byUserCode: "abcd-efgh")
+        #expect(notFound == nil)
+    }
+
+    // MARK: - updateDevice
+
+    @Test("updateDevice changes status to authorized")
+    func updateDeviceToAuthorized() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        try await storage.updateDevice(
+            deviceCode: "dev-code-0001",
+            newStatus: .authorized,
+            payload: nil,
+            lastPolledAt: nil
+        )
+
+        let updated = await storage.get(type: .device, codeValue: "dev-code-0001")
+        guard case .device(let data) = updated else {
+            Issue.record("Expected device session after update")
+            return
+        }
+        #expect(data.status == .authorized)
+    }
+
+    @Test("updateDevice changes status to denied")
+    func updateDeviceToDenied() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        try await storage.updateDevice(
+            deviceCode: "dev-code-0001",
+            newStatus: .denied,
+            payload: nil,
+            lastPolledAt: nil
+        )
+
+        let updated = await storage.get(type: .device, codeValue: "dev-code-0001")
+        guard case .device(let data) = updated else {
+            Issue.record("Expected device session after update")
+            return
+        }
+        #expect(data.status == .denied)
+    }
+
+    @Test("updateDevice records lastPolledAt")
+    func updateDeviceRecordsLastPolledAt() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        let pollTime = Date()
+        try await storage.updateDevice(
+            deviceCode: "dev-code-0001",
+            newStatus: .pending,
+            payload: nil,
+            lastPolledAt: pollTime
+        )
+
+        let updated = await storage.get(type: .device, codeValue: "dev-code-0001")
+        guard case .device(let data) = updated else {
+            Issue.record("Expected device session after update")
+            return
+        }
+        #expect(data.lastPolledAt != nil)
+    }
+
+    @Test("updateDevice preserves userCode in secondary index")
+    func updateDevicePreservesUserCode() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        try await storage.updateDevice(
+            deviceCode: "dev-code-0001",
+            newStatus: .authorized,
+            payload: nil,
+            lastPolledAt: nil
+        )
+
+        let foundByUserCode = await storage.getDevice(byUserCode: "ABCD-EFGH")
+        #expect(foundByUserCode != nil)
+    }
+
+    @Test("updateDevice with unknown device code throws")
+    func updateDeviceUnknownCodeThrows() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+
+        do {
+            try await storage.updateDevice(
+                deviceCode: "nonexistent-code",
+                newStatus: .authorized,
+                payload: nil,
+                lastPolledAt: nil
+            )
+            Issue.record("Expected error to be thrown for unknown device code")
+        } catch {
+            // Expected: no matching session found
+        }
+    }
+
+    // MARK: - delete
+
+    @Test("delete removes device session")
+    func deleteDeviceSession() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        try await storage.delete(type: .device, codeValue: "dev-code-0001")
+
+        let found = await storage.get(type: .device, codeValue: "dev-code-0001")
+        #expect(found == nil)
+    }
+
+    @Test("delete also removes secondary user code lookup")
+    func deleteRemovesUserCodeLookup() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession())
+
+        try await storage.delete(type: .device, codeValue: "dev-code-0001")
+
+        let foundByUserCode = await storage.getDevice(byUserCode: "ABCD-EFGH")
+        #expect(foundByUserCode == nil)
+    }
+
+    @Test("multiple device sessions are stored independently")
+    func multipleDeviceSessions() async throws {
+        let storage = AuthCodeStorage(use: .memory)
+        try await storage.set(authSession: makeDeviceSession(
+            deviceCode: "dev-code-AAA1", userCode: "AAAA-BBBB"
+        ))
+        try await storage.set(authSession: makeDeviceSession(
+            deviceCode: "dev-code-BBB1", userCode: "CCCC-DDDD"
+        ))
+
+        let firstSession = await storage.getDevice(byUserCode: "AAAA-BBBB")
+        let secondSession = await storage.getDevice(byUserCode: "CCCC-DDDD")
+
+        #expect(firstSession != nil)
+        #expect(secondSession != nil)
+        #expect(firstSession?.codeValue != secondSession?.codeValue)
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/Controllers/ActivateControllerTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Controllers/ActivateControllerTests.swift
@@ -1,0 +1,269 @@
+import Foundation
+import Testing
+import VaporTesting
+@testable import Uitsmijter_AuthServer
+
+/// Form data for the activation endpoint.
+private struct ActivateFormData: Content, Sendable {
+    var user_code: String
+    var username: String
+    var password: String
+}
+
+@Suite("Activate Controller Tests", .serialized)
+struct ActivateControllerTests {
+    let testAppIdent = UUID()
+
+    // MARK: - Helpers
+
+    private func seedPendingDeviceSession(
+        in storage: AuthCodeStorage,
+        deviceCode: String,
+        userCode: String,
+        clientId: String
+    ) async throws {
+        let session = AuthSession.device(DeviceSession(
+            clientId: clientId,
+            deviceCode: Code(value: deviceCode),
+            userCode: userCode,
+            scopes: ["read"],
+            payload: nil,
+            status: .pending
+        ))
+        try await storage.set(authSession: session)
+    }
+
+    // MARK: - GET /activate
+
+    @Test("GET /activate returns ok status")
+    func getActivateReturnsOk() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/activate", afterResponse: { @Sendable res async throws in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("DOCTYPE html"))
+            })
+        }
+    }
+
+    @Test("GET /activate renders the activation form with form element")
+    func getActivateRendersForm() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(.GET, "/activate", afterResponse: { @Sendable res async throws in
+                #expect(res.status == .ok)
+                #expect(res.body.string.contains("action=\"/activate\""))
+            })
+        }
+    }
+
+    @Test("GET /activate?user_code= prefills the user code field")
+    func getActivateWithUserCodeParam() async throws {
+        try await withApp(configure: configure) { app in
+            try await app.testing().test(
+                .GET,
+                "/activate?user_code=ABCD-EFGH",
+                afterResponse: { @Sendable res async throws in
+                    #expect(res.status == .ok)
+                    #expect(res.body.string.contains("ABCD-EFGH"))
+                }
+            )
+        }
+    }
+
+    // MARK: - POST /activate
+
+    @Test("POST /activate without user_code returns bad request")
+    func postActivateMissingUserCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    req.headers.contentType = .urlEncodedForm
+                    req.body = .init(string: "username=valid_user&password=valid_password")
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("POST /activate with invalid user code returns bad request")
+    func postActivateInvalidUserCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    try req.content.encode(
+                        ActivateFormData(
+                            user_code: "UNKN-OWNN",
+                            username: "valid_user",
+                            password: "valid_password"
+                        ),
+                        as: .urlEncodedForm
+                    )
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("POST /activate with valid credentials and user code succeeds")
+    func postActivateValidCredentials() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent, script: .johnDoe)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+            let knownUserCode = "VALD-TEST"
+            try await seedPendingDeviceSession(
+                in: storage,
+                deviceCode: "valid-device-code-0001",
+                userCode: knownUserCode,
+                clientId: testAppIdent.uuidString
+            )
+
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    try req.content.encode(
+                        ActivateFormData(
+                            user_code: knownUserCode,
+                            username: "valid_user",
+                            password: "valid_password"
+                        ),
+                        as: .urlEncodedForm
+                    )
+                }
+            )
+
+            #expect(response.status == .ok)
+
+            // Session should now be authorized
+            let updated = await storage.get(type: .device, codeValue: "valid-device-code-0001")
+            guard case .device(let deviceData) = updated else {
+                Issue.record("Expected device session to still exist after authorization")
+                return
+            }
+            #expect(deviceData.status == .authorized)
+            #expect(deviceData.payload != nil)
+        }
+    }
+
+    @Test("POST /activate with wrong credentials returns forbidden")
+    func postActivateWrongCredentials() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent, script: .johnDoe)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+            let knownUserCode = "BADC-REDS"
+            try await seedPendingDeviceSession(
+                in: storage,
+                deviceCode: "bad-creds-device-code-01",
+                userCode: knownUserCode,
+                clientId: testAppIdent.uuidString
+            )
+
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    try req.content.encode(
+                        ActivateFormData(
+                            user_code: knownUserCode,
+                            username: "valid_user",
+                            password: "wrong_password"
+                        ),
+                        as: .urlEncodedForm
+                    )
+                }
+            )
+
+            #expect(response.status == .forbidden)
+        }
+    }
+
+    @Test("POST /activate with already-authorized code returns bad request")
+    func postActivateAlreadyAuthorizedCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent, script: .johnDoe)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+
+            let knownUserCode = "ALRD-AUTH"
+            // Store with already-authorized status
+            let session = AuthSession.device(DeviceSession(
+                clientId: testAppIdent.uuidString,
+                deviceCode: Code(value: "already-auth-device-001"),
+                userCode: knownUserCode,
+                scopes: ["read"],
+                payload: nil,
+                status: .authorized
+            ))
+            try await storage.set(authSession: session)
+
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    try req.content.encode(
+                        ActivateFormData(
+                            user_code: knownUserCode,
+                            username: "valid_user",
+                            password: "valid_password"
+                        ),
+                        as: .urlEncodedForm
+                    )
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("POST /activate normalizes user code to uppercase XXXX-XXXX format")
+    func postActivateNormalizesUserCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent, script: .johnDoe)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+            let knownUserCode = "NORM-ALZE"
+            try await seedPendingDeviceSession(
+                in: storage,
+                deviceCode: "normalize-device-code-001",
+                userCode: knownUserCode,
+                clientId: testAppIdent.uuidString
+            )
+
+            // Submit lower-case without dash — should be normalized to "NORM-ALZE"
+            let response = try await app.sendRequest(
+                .POST, "/activate",
+                beforeRequest: { @Sendable req async throws in
+                    try req.content.encode(
+                        ActivateFormData(
+                            user_code: "normalze",
+                            username: "valid_user",
+                            password: "valid_password"
+                        ),
+                        as: .urlEncodedForm
+                    )
+                }
+            )
+
+            // "normalze" is 8 chars → normalized to "NORM-ALZE"
+            #expect(response.status == .ok)
+        }
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/Controllers/DeviceControllerTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Controllers/DeviceControllerTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+import VaporTesting
+@testable import Uitsmijter_AuthServer
+
+@Suite("Device Controller Tests", .serialized)
+struct DeviceControllerTests {
+    let testAppIdent = UUID()
+
+    // MARK: - POST /oauth/device_authorization
+
+    @Test("Valid device authorization request returns device_code and user_code")
+    func deviceAuthorizationReturnsDeviceAndUserCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: "read"
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .ok)
+            guard let body = try? response.content.decode(DeviceAuthorizationResponse.self) else {
+                Issue.record("Failed to decode DeviceAuthorizationResponse")
+                return
+            }
+            #expect(body.device_code.count == 32)
+            #expect(body.user_code.count == 9)
+            #expect(body.user_code.contains("-"))
+            #expect(body.expires_in == 1800)
+            #expect(body.interval == 5)
+            #expect(!body.verification_uri.isEmpty)
+        }
+    }
+
+    @Test("Device authorization stores session in storage")
+    func deviceAuthorizationStoresSession() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .ok)
+            guard let body = try? response.content.decode(DeviceAuthorizationResponse.self) else {
+                Issue.record("Failed to decode DeviceAuthorizationResponse")
+                return
+            }
+
+            let stored = await app.authCodeStorage?.get(type: .device, codeValue: body.device_code)
+            #expect(stored != nil)
+            guard case .device(let deviceData) = stored else {
+                Issue.record("Expected device session in storage")
+                return
+            }
+            #expect(deviceData.status == .pending)
+            #expect(deviceData.userCode == body.user_code)
+        }
+    }
+
+    @Test("Device authorization user code has correct XXXX-XXXX format")
+    func deviceAuthorizationUserCodeFormat() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            guard let body = try? response.content.decode(DeviceAuthorizationResponse.self) else {
+                Issue.record("Failed to decode DeviceAuthorizationResponse")
+                return
+            }
+            let parts = body.user_code.components(separatedBy: "-")
+            #expect(parts.count == 2)
+            #expect(parts[0].count == 4)
+            #expect(parts[1].count == 4)
+        }
+    }
+
+    @Test("Device authorization with unknown client returns not found")
+    func deviceAuthorizationUnknownClientReturnsNotFound() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: UUID().uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .notFound)
+        }
+    }
+
+    @Test("Device authorization with device_grant_config but device_code not in grant_types returns bad request")
+    func deviceAuthorizationGrantConfigPresentButGrantTypeMissing() async throws {
+        try await withApp(configure: configure) { app in
+            // Client has device_grant_config but device_code is NOT listed in grant_types
+            await MainActor.run {
+                app.entityStorage.tenants.removeAll()
+                app.entityStorage.clients.removeAll()
+                let tenant = Tenant(
+                    name: "Test Tenant",
+                    config: TenantSpec(hosts: ["localhost"])
+                )
+                app.entityStorage.tenants.insert(tenant)
+                app.entityStorage.clients = [
+                    Client(
+                        name: "Config Without Grant Type",
+                        config: ClientSpec(
+                            ident: testAppIdent,
+                            tenantname: "Test Tenant",
+                            redirect_urls: ["http://localhost"],
+                            grant_types: ["authorization_code"],
+                            device_grant_config: DeviceGrantConfig(
+                                expires_in: 1800,
+                                interval: 5,
+                                verification_uri: nil
+                            )
+                        )
+                    )
+                ]
+            }
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Device authorization without device_grant_config returns bad request")
+    func deviceAuthorizationNoGrantConfigReturnsBadRequest() async throws {
+        try await withApp(configure: configure) { app in
+            // generateTestClient creates a client WITHOUT device_grant_config
+            await generateTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Device authorization verification_uri contains /activate path")
+    func deviceAuthorizationVerificationUriContainsActivatePath() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: nil
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            guard let body = try? response.content.decode(DeviceAuthorizationResponse.self) else {
+                Issue.record("Failed to decode DeviceAuthorizationResponse")
+                return
+            }
+            #expect(body.verification_uri.contains("/activate"))
+        }
+    }
+
+    @Test("Device authorization with scope stores scopes in session")
+    func deviceAuthorizationWithScopeStoresScope() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent, scopes: ["read", "write"])
+
+            let response = try await app.sendRequest(
+                .POST, "/oauth/device_authorization",
+                beforeRequest: { @Sendable req async throws in
+                    let deviceRequest = DeviceAuthorizationRequest(
+                        client_id: testAppIdent.uuidString,
+                        scope: "read"
+                    )
+                    try req.content.encode(deviceRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            guard let body = try? response.content.decode(DeviceAuthorizationResponse.self) else {
+                Issue.record("Failed to decode DeviceAuthorizationResponse")
+                return
+            }
+            let stored = await app.authCodeStorage?.get(type: .device, codeValue: body.device_code)
+            guard case .device(let deviceData) = stored else {
+                Issue.record("Expected device session in storage")
+                return
+            }
+            #expect(deviceData.scopes.contains("read"))
+        }
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/Controllers/TokenControllerDeviceGrantTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Controllers/TokenControllerDeviceGrantTest.swift
@@ -1,0 +1,273 @@
+import Foundation
+import Testing
+import VaporTesting
+import JWTKit
+@testable import Uitsmijter_AuthServer
+
+@Suite("Token Controller Device Grant Tests", .serialized)
+struct TokenControllerDeviceGrantTest {
+    let testAppIdent = UUID()
+
+    // MARK: - Helpers
+
+    private func makeDeviceTokenRequest(
+        clientId: String,
+        deviceCode: String
+    ) -> DeviceTokenRequest {
+        DeviceTokenRequest(
+            grant_type: .device_code,
+            client_id: clientId,
+            client_secret: nil,
+            device_code: deviceCode
+        )
+    }
+
+    private func seedPendingSession(in storage: AuthCodeStorage, deviceCode: String, clientId: String) async throws {
+        let session = AuthSession.device(DeviceSession(
+            clientId: clientId,
+            deviceCode: Code(value: deviceCode),
+            userCode: "ABCD-1234",
+            scopes: ["read"],
+            payload: nil,
+            status: .pending
+        ))
+        try await storage.set(authSession: session)
+    }
+
+    private func makeTestPayload(clientId: String, tenantName: String) -> Payload {
+        let expirationDate = Date(timeIntervalSinceNow: 90 * 86_400)
+        return Payload(
+            issuer: IssuerClaim(value: "https://localhost"),
+            subject: "valid_user",
+            audience: AudienceClaim(value: clientId),
+            expiration: ExpirationClaim(value: expirationDate),
+            issuedAt: IssuedAtClaim(value: Date()),
+            authTime: AuthTimeClaim(value: Date()),
+            tenant: tenantName,
+            role: "user",
+            user: "valid_user",
+            scope: "read"
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test("Device token grant with unknown device code returns bad request")
+    func deviceTokenUnknownDeviceCode() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: "nonexistent-device-code-01"
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Device token grant with pending status returns bad request")
+    func deviceTokenPendingStatusReturnsBadRequest() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+            let knownDeviceCode = "pending-device-code-001"
+            try await seedPendingSession(
+                in: storage,
+                deviceCode: knownDeviceCode,
+                clientId: testAppIdent.uuidString
+            )
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: knownDeviceCode
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Device token grant with denied status returns bad request")
+    func deviceTokenDeniedStatusReturnsBadRequest() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+            let knownDeviceCode = "denied-device-code-001"
+            let session = AuthSession.device(DeviceSession(
+                clientId: testAppIdent.uuidString,
+                deviceCode: Code(value: knownDeviceCode),
+                userCode: "DENI-EDDD",
+                scopes: ["read"],
+                payload: nil,
+                status: .denied
+            ))
+            try await storage.set(authSession: session)
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: knownDeviceCode
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .badRequest)
+        }
+    }
+
+    @Test("Device token grant with authorized status returns access token")
+    func deviceTokenAuthorizedStatusReturnsAccessToken() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+
+            let knownDeviceCode = "authorized-device-code-1"
+            let payload = makeTestPayload(
+                clientId: testAppIdent.uuidString,
+                tenantName: "Test Tenant"
+            )
+            let session = AuthSession.device(DeviceSession(
+                clientId: testAppIdent.uuidString,
+                deviceCode: Code(value: knownDeviceCode),
+                userCode: "AUTH-ORZE",
+                scopes: ["read"],
+                payload: payload,
+                status: .authorized
+            ))
+            try await storage.set(authSession: session)
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: knownDeviceCode
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .ok)
+            guard let tokenResponse = try? response.content.decode(TokenResponse.self) else {
+                Issue.record("Failed to decode TokenResponse")
+                return
+            }
+            #expect(tokenResponse.access_token.count > 64)
+            #expect(tokenResponse.token_type == .Bearer)
+            #expect(tokenResponse.expires_in != nil)
+        }
+    }
+
+    @Test("Device token grant with authorized status removes session from storage")
+    func deviceTokenAuthorizedDeletesSession() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+
+            let knownDeviceCode = "authorized-device-del-1"
+            let payload = makeTestPayload(
+                clientId: testAppIdent.uuidString,
+                tenantName: "Test Tenant"
+            )
+            let session = AuthSession.device(DeviceSession(
+                clientId: testAppIdent.uuidString,
+                deviceCode: Code(value: knownDeviceCode),
+                userCode: "DELE-TEST",
+                scopes: ["read"],
+                payload: payload,
+                status: .authorized
+            ))
+            try await storage.set(authSession: session)
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: knownDeviceCode
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .ok)
+            let gone = await storage.get(type: .device, codeValue: knownDeviceCode)
+            #expect(gone == nil)
+        }
+    }
+
+    @Test("Device token grant with rapid polling returns slow_down (429)")
+    func deviceTokenRapidPollingReturnsTooManyRequests() async throws {
+        try await withApp(configure: configure) { app in
+            await generateDeviceTestClient(in: app.entityStorage, uuid: testAppIdent)
+
+            guard let storage = app.authCodeStorage else {
+                Issue.record("authCodeStorage not available")
+                return
+            }
+
+            let knownDeviceCode = "slow-down-device-code-1"
+            let recentPollTime = Date()
+            let session = AuthSession.device(DeviceSession(
+                clientId: testAppIdent.uuidString,
+                deviceCode: Code(value: knownDeviceCode),
+                userCode: "SLOW-DOWN",
+                scopes: ["read"],
+                payload: nil,
+                status: .pending,
+                lastPolledAt: recentPollTime
+            ))
+            try await storage.set(authSession: session)
+
+            let response = try await app.sendRequest(
+                .POST, "/token",
+                beforeRequest: { @Sendable req async throws in
+                    let tokenRequest = self.makeDeviceTokenRequest(
+                        clientId: self.testAppIdent.uuidString,
+                        deviceCode: knownDeviceCode
+                    )
+                    try req.content.encode(tokenRequest, as: .json)
+                    req.headers.contentType = .json
+                }
+            )
+
+            #expect(response.status == .tooManyRequests)
+        }
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/Entities/ClientStatusInitializationTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Entities/ClientStatusInitializationTest.swift
@@ -51,15 +51,14 @@ struct ClientStatusInitializationTest {
             profile: nil
         )
 
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "test-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
 
         try await authStorage.set(authSession: refreshSession)
 
@@ -104,15 +103,14 @@ struct ClientStatusInitializationTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await authStorage.set(authSession: refreshSession)
         }
@@ -134,15 +132,14 @@ struct ClientStatusInitializationTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await authStorage.set(authSession: refreshSession)
         }

--- a/Tests/Uitsmijter-AuthServerTests/Entities/ClientStatusUpdateTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Entities/ClientStatusUpdateTest.swift
@@ -50,15 +50,14 @@ struct ClientStatusUpdateTest {
             profile: nil
         )
 
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "test-state",
             code: Code(),
             scopes: ["openid", "profile"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
 
         try await storage.set(authSession: refreshSession)
 
@@ -92,15 +91,14 @@ struct ClientStatusUpdateTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await storage.set(authSession: refreshSession)
         }
@@ -122,15 +120,14 @@ struct ClientStatusUpdateTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await storage.set(authSession: refreshSession)
         }
@@ -167,15 +164,14 @@ struct ClientStatusUpdateTest {
             profile: nil
         )
 
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "test-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
 
         try await storage.set(authSession: refreshSession)
 
@@ -210,27 +206,25 @@ struct ClientStatusUpdateTest {
         )
 
         // Create authorization code (should NOT be counted in refresh count)
-        let authCodeSession = AuthSession(
-            type: .code,
+        let authCodeSession = AuthSession.code(CodeSession(
             state: "auth-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: 600
-        )
+        ))
         try await storage.set(authSession: authCodeSession)
 
         // Create refresh token (should be counted)
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "refresh-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
         try await storage.set(authSession: refreshSession)
 
         // Only refresh tokens should be counted

--- a/Tests/Uitsmijter-AuthServerTests/Entities/TenantStatusUpdateTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Entities/TenantStatusUpdateTest.swift
@@ -40,15 +40,14 @@ struct TenantStatusUpdateTest {
             profile: nil
         )
 
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "test-state",
             code: Code(),
             scopes: ["openid", "profile"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
 
         try await storage.set(authSession: refreshSession)
 
@@ -80,15 +79,14 @@ struct TenantStatusUpdateTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "test-state-\(index)",
                 code: Code(),
                 scopes: ["openid", "profile"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await storage.set(authSession: refreshSession)
         }
@@ -129,15 +127,14 @@ struct TenantStatusUpdateTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await storage.set(authSession: refreshSession)
         }
@@ -159,15 +156,14 @@ struct TenantStatusUpdateTest {
                 profile: nil
             )
 
-            let refreshSession = AuthSession(
-                type: .refresh,
+            let refreshSession = AuthSession.refresh(RefreshSession(
                 state: "state-\(index)",
                 code: Code(),
                 scopes: ["openid"],
                 payload: payload,
                 redirect: "https://example.com/callback",
                 ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-            )
+            ))
 
             try await storage.set(authSession: refreshSession)
         }
@@ -202,27 +198,25 @@ struct TenantStatusUpdateTest {
         )
 
         // Create authorization code (should NOT be counted)
-        let authCodeSession = AuthSession(
-            type: .code,
+        let authCodeSession = AuthSession.code(CodeSession(
             state: "auth-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: 600
-        )
+        ))
         try await storage.set(authSession: authCodeSession)
 
         // Create refresh token (should be counted)
-        let refreshSession = AuthSession(
-            type: .refresh,
+        let refreshSession = AuthSession.refresh(RefreshSession(
             state: "refresh-state",
             code: Code(),
             scopes: ["openid"],
             payload: payload,
             redirect: "https://example.com/callback",
             ttl: (Int64(Constants.TOKEN.REFRESH_EXPIRATION_IN_HOURS) * 60 * 60)
-        )
+        ))
         try await storage.set(authSession: refreshSession)
 
         // Only refresh tokens should be counted

--- a/Tests/Uitsmijter-AuthServerTests/OAuth/AuthorisationUtils.swift
+++ b/Tests/Uitsmijter-AuthServerTests/OAuth/AuthorisationUtils.swift
@@ -531,3 +531,48 @@ func authorisationCodeGrantFlow(
     #expect(loginRedirectState == state)
     return code
 }
+
+/// Generate a test client with Device Authorization Grant configured (RFC 8628).
+///
+/// Creates a client with `device_grant_config` and `device_code` in `grant_types`,
+/// ready for use in device grant flow tests.
+///
+/// - Parameters:
+///   - storage: Entity storage to populate
+///   - clientIdent: UUID for the test client
+///   - script: JavaScript provider script to use
+///   - scopes: Allowed scopes (defaults to ["read"])
+///   - expiresIn: Device code lifetime in seconds (default 1800)
+///   - interval: Minimum polling interval in seconds (default 5)
+@MainActor
+func generateDeviceTestClient(
+    in storage: EntityStorage,
+    uuid clientIdent: UUID,
+    script: TestTenantScripts? = .johnDoe,
+    scopes: [String]? = nil,
+    expiresIn: Int = 1800,
+    interval: Int = 5
+) {
+    storage.tenants.removeAll()
+    storage.clients.removeAll()
+    let tenant = createTenant(in: storage, script: script ?? .johnDoe)
+
+    let deviceGrantTypes: [String] = [GrantTypes.device_code.rawValue]
+    let deviceGrantConfig = DeviceGrantConfig(
+        expires_in: expiresIn,
+        interval: interval,
+        verification_uri: nil
+    )
+    let client = Client(
+        name: "Device Test Client",
+        config: ClientSpec(
+            ident: clientIdent,
+            tenantname: tenant.name,
+            redirect_urls: ["http://localhost:?([0-9]+)?", "http://example.com"],
+            grant_types: deviceGrantTypes,
+            scopes: scopes ?? ["read"],
+            device_grant_config: deviceGrantConfig
+        )
+    )
+    storage.clients = [client]
+}

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
@@ -278,7 +278,9 @@ struct JSFunctionsNetworkingTest {
             }
         """)
 
-        let credentials = JSInputCredentials(username: "test@example.com", password: "test")
+        let credentials = JSInputCredentials(
+            username: "test@example.com", password: "test", grantType: .authorization_code
+        )
         let results = try await jsp.start(class: .userLogin, arguments: credentials)
 
         // Verify we got a result

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
@@ -85,14 +85,19 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials initializes with username and password")
     func jsInputCredentialsInitialization() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "secret123")
+        let credentials = JSInputCredentials(
+            username: "user@test.com", password: "secret123", grantType: .authorization_code
+        )
         #expect(credentials.username == "user@test.com")
         #expect(credentials.password == "secret123")
+        #expect(credentials.grantType == .authorization_code)
     }
 
     @Test("JSInputCredentials toJSON produces valid JSON")
     func jsInputCredentialsToJSON() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "pass123")
+        let credentials = JSInputCredentials(
+            username: "user@test.com", password: "pass123", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json != nil)
@@ -100,23 +105,33 @@ struct JSInputParameterTest {
         #expect(json?.contains("pass123") == true)
         #expect(json?.contains("username") == true)
         #expect(json?.contains("password") == true)
+        #expect(json?.contains("grant_type") == true)
+        #expect(json?.contains("authorization_code") == true)
     }
 
     @Test("JSInputCredentials toJSON format is correct")
     func jsInputCredentialsJSONFormat() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "mypass")
+        let credentials = JSInputCredentials(
+            username: "user@test.com", password: "mypass", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
-        // Order might vary, so check both possibilities
-        let validFormat1 = "{\"username\":\"user@test.com\",\"password\":\"mypass\"}"
-        let validFormat2 = "{\"password\":\"mypass\",\"username\":\"user@test.com\"}"
-
-        #expect(json == validFormat1 || json == validFormat2)
+        // Parse and verify fields rather than checking exact format (key order may vary)
+        guard let data = json?.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(JSInputCredentials.self, from: data) else {
+            Issue.record("Failed to parse JSON output")
+            return
+        }
+        #expect(parsed.username == "user@test.com")
+        #expect(parsed.password == "mypass")
+        #expect(parsed.grantType == .authorization_code)
     }
 
     @Test("JSInputCredentials encodes with special characters")
     func jsInputCredentialsWithSpecialChars() throws {
-        let credentials = JSInputCredentials(username: "test+user@example.com", password: "p@ss!word#123")
+        let credentials = JSInputCredentials(
+            username: "test+user@example.com", password: "p@ss!word#123", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json?.contains("test+user@example.com") == true)
@@ -125,7 +140,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty password")
     func jsInputCredentialsEmptyPassword() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "")
+        let credentials = JSInputCredentials(username: "user@test.com", password: "", grantType: .authorization_code)
         let json = try credentials.toJSON()
 
         #expect(json?.contains("user@test.com") == true)
@@ -134,7 +149,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty username")
     func jsInputCredentialsEmptyUsername() throws {
-        let credentials = JSInputCredentials(username: "", password: "password")
+        let credentials = JSInputCredentials(username: "", password: "password", grantType: .authorization_code)
         let json = try credentials.toJSON()
 
         #expect(json?.contains("username") == true)
@@ -143,7 +158,9 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with unicode")
     func jsInputCredentialsWithUnicode() throws {
-        let credentials = JSInputCredentials(username: "用户@example.com", password: "密码123")
+        let credentials = JSInputCredentials(
+            username: "用户@example.com", password: "密码123", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json != nil)
@@ -153,17 +170,20 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials decodes from JSON")
     func jsInputCredentialsDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com","password":"decodedpass"}
+        {"username":"decoded@example.com","password":"decodedpass","grant_type":"authorization_code"}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
         #expect(decoded.password == "decodedpass")
+        #expect(decoded.grantType == .authorization_code)
     }
 
     @Test("JSInputCredentials round-trip encoding and decoding")
     func jsInputCredentialsRoundTrip() throws {
-        let original = JSInputCredentials(username: "roundtrip@test.com", password: "roundtrippass")
+        let original = JSInputCredentials(
+            username: "roundtrip@test.com", password: "roundtrippass", grantType: .password
+        )
         let json = try original.toJSON()
 
         guard let jsonString = json else {
@@ -175,6 +195,7 @@ struct JSInputParameterTest {
 
         #expect(decoded.username == original.username)
         #expect(decoded.password == original.password)
+        #expect(decoded.grantType == original.grantType)
     }
 
     // MARK: - Protocol Conformance Tests
@@ -191,7 +212,8 @@ struct JSInputParameterTest {
     func jsInputCredentialsConformsToProtocol() throws {
         let credentials: any JSInputParameterProtocol = JSInputCredentials(
             username: "test@example.com",
-            password: "password"
+            password: "password",
+            grantType: .authorization_code
         )
         let json = try credentials.toJSON()
 
@@ -209,12 +231,15 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials conforms to Codable")
     func jsInputCredentialsConformsToCodable() throws {
-        let credentials = JSInputCredentials(username: "test@example.com", password: "password")
+        let credentials = JSInputCredentials(
+            username: "test@example.com", password: "password", grantType: .interceptor
+        )
         let encoded = try JSONEncoder().encode(credentials)
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: encoded)
 
         #expect(decoded.username == credentials.username)
         #expect(decoded.password == credentials.password)
+        #expect(decoded.grantType == credentials.grantType)
     }
 
     @Test("JSInputUsername conforms to Sendable")
@@ -232,7 +257,9 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials conforms to Sendable")
     func jsInputCredentialsConformsToSendable() throws {
-        let credentials = JSInputCredentials(username: "test@example.com", password: "password")
+        let credentials = JSInputCredentials(
+            username: "test@example.com", password: "password", grantType: .authorization_code
+        )
 
         // Sendable conformance is compile-time checked
         // This test verifies it can be used in async contexts
@@ -259,7 +286,9 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials with very long password")
     func jsInputCredentialsVeryLongPassword() throws {
         let longPassword = String(repeating: "x", count: 1000)
-        let credentials = JSInputCredentials(username: "test@example.com", password: longPassword)
+        let credentials = JSInputCredentials(
+            username: "test@example.com", password: longPassword, grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json != nil)
@@ -268,7 +297,9 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials with newlines in password")
     func jsInputCredentialsWithNewlines() throws {
-        let credentials = JSInputCredentials(username: "test@example.com", password: "pass\nword")
+        let credentials = JSInputCredentials(
+            username: "test@example.com", password: "pass\nword", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json != nil)
@@ -288,7 +319,9 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials with backslashes")
     func jsInputCredentialsWithBackslashes() throws {
-        let credentials = JSInputCredentials(username: "test\\user@example.com", password: "pass\\word")
+        let credentials = JSInputCredentials(
+            username: "test\\user@example.com", password: "pass\\word", grantType: .authorization_code
+        )
         let json = try credentials.toJSON()
 
         #expect(json != nil)

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
@@ -4,7 +4,9 @@ import Testing
 @testable import Uitsmijter_AuthServer
 @Suite("JavaScript Provider Get Properties Tests")
 struct JavaScriptProviderGetPropertiesTest {
-    let dummyCredentials = JSInputCredentials(username: "test@example.com", password: "test")
+    let dummyCredentials = JSInputCredentials(
+        username: "test@example.com", password: "test", grantType: .authorization_code
+    )
     @Test("getSubject returns committed subject from script")
     func getSubjectReturnsCommittedSubject() async throws {
         let jsp = JavaScriptProvider()

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
@@ -6,7 +6,9 @@ import Testing
 @Suite("JavaScript Provider Core Tests")
 struct JavaScriptProviderTest {
 
-    let dummyCredentials = JSInputCredentials(username: "test@example.com", password: "test")
+    let dummyCredentials = JSInputCredentials(
+        username: "test@example.com", password: "test", grantType: .authorization_code
+    )
 
     @Test("JavaScriptProvider initializes successfully")
     func providerInitializes() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
@@ -31,8 +31,12 @@ struct UserLoginCommittedSubjectTest {
                                      }
                                      """
 
-    let userOK = JSInputCredentials(username: "ok@example.com", password: "very-secret")
-    let userDenied = JSInputCredentials(username: "deni@example.com", password: "very-secret")
+    let userOK = JSInputCredentials(
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+    )
+    let userDenied = JSInputCredentials(
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+    )
 
     @Test("Get committed value can login")
     func getCommittedValue_canLogin() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
@@ -35,8 +35,12 @@ struct UserLoginProviderTests {
                                      }
                                      """
 
-    let userOK = JSInputCredentials(username: "ok@example.com", password: "very-secret")
-    let userDenied = JSInputCredentials(username: "deni@example.com", password: "very-secret")
+    let userOK = JSInputCredentials(
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+    )
+    let userDenied = JSInputCredentials(
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+    )
 
     @Test("Get example with callback")
     func getExampleCallback() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/WellKnown/OpenidConfigurationBuilderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/WellKnown/OpenidConfigurationBuilderTest.swift
@@ -437,6 +437,71 @@ struct OpenidConfigurationBuilderTest {
         #expect(scopes.contains("admin"))
     }
 
+    // MARK: - Device Authorization Endpoint Tests
+
+    @Test("Builder includes device_authorization_endpoint when a client has device_code grant type")
+    func builderIncludesDeviceAuthorizationEndpointForDeviceCodeClient() async throws {
+        let app = try await createTestApp()
+        defer { Task { try? await app.asyncShutdown() } }
+
+        let tenant = createTestTenant(name: "DeviceTenant", hosts: ["device.example.com"])
+        app.entityStorage.tenants.insert(tenant)
+
+        let client = createTestClient(
+            name: "DeviceClient",
+            tenantName: "DeviceTenant",
+            grantTypes: ["device_code"]
+        )
+        app.entityStorage.clients.append(client)
+
+        let builder = OpenidConfigurationBuilder()
+        let request = createMockRequest(app: app, host: "device.example.com")
+
+        let config = builder.build(for: tenant, request: request, storage: app.entityStorage)
+
+        #expect(config.device_authorization_endpoint == "https://device.example.com/oauth/device_authorization")
+        #expect(config.grant_types_supported?.contains("device_code") == true)
+    }
+
+    @Test("Builder omits device_authorization_endpoint when no client has device_code grant type")
+    func builderOmitsDeviceAuthorizationEndpointWithoutDeviceCodeClient() async throws {
+        let app = try await createTestApp()
+        defer { Task { try? await app.asyncShutdown() } }
+
+        let tenant = createTestTenant(name: "NoDeviceTenant", hosts: ["nodevice.example.com"])
+        app.entityStorage.tenants.insert(tenant)
+
+        let client = createTestClient(
+            name: "RegularClient",
+            tenantName: "NoDeviceTenant",
+            grantTypes: ["authorization_code", "refresh_token"]
+        )
+        app.entityStorage.clients.append(client)
+
+        let builder = OpenidConfigurationBuilder()
+        let request = createMockRequest(app: app, host: "nodevice.example.com")
+
+        let config = builder.build(for: tenant, request: request, storage: app.entityStorage)
+
+        #expect(config.device_authorization_endpoint == nil)
+    }
+
+    @Test("Builder omits device_authorization_endpoint when tenant has no clients")
+    func builderOmitsDeviceAuthorizationEndpointForTenantWithNoClients() async throws {
+        let app = try await createTestApp()
+        defer { Task { try? await app.asyncShutdown() } }
+
+        let tenant = createTestTenant(name: "EmptyTenant", hosts: ["empty2.example.com"])
+        app.entityStorage.tenants.insert(tenant)
+
+        let builder = OpenidConfigurationBuilder()
+        let request = createMockRequest(app: app, host: "empty2.example.com")
+
+        let config = builder.build(for: tenant, request: request, storage: app.entityStorage)
+
+        #expect(config.device_authorization_endpoint == nil)
+    }
+
     @Test("Builder sorts scopes alphabetically")
     func builderSortsScopesAlphabetically() async throws {
         let app = try await createTestApp()

--- a/Tests/e2e/playwright/tests/GrantType/GrantTypeCheck.spec.ts
+++ b/Tests/e2e/playwright/tests/GrantType/GrantTypeCheck.spec.ts
@@ -1,0 +1,69 @@
+import {test, expect} from '@playwright/test';
+import {Application} from "../Fixtures/app";
+import {loginAuthorizeFormRequest} from "../OAuth/AuthorizeRequests";
+
+const hamAuthUrl = 'https://id.ham.test';
+const hamClientId = 'cd7a444a-7aa9-4f27-9305-9e2a9c4d47ee';
+const hamRedirectUri = 'https://id.ham.test/callback';
+const validUsername = 'test@example.com';
+
+// The Ham tenant provider denies logins when grant_type is 'interceptor'.
+// These tests verify that an OAuth login succeeds and an interceptor login is denied.
+
+test.describe('Grant type check in provider', () => {
+
+    test.describe('happy path: authorization_code grant is allowed', () => {
+        test.describe.configure({mode: 'serial'});
+
+        const myState = Math.floor(Math.random() * 999999999);
+
+        test('should return an authorization code for a valid OAuth login', async ({page}) => {
+            const response = await loginAuthorizeFormRequest(
+                page,
+                hamAuthUrl,
+                {
+                    client_id: hamClientId,
+                    redirect_uri: hamRedirectUri,
+                    response_type: 'code',
+                    scope: '',
+                    state: '' + myState,
+                    username: validUsername,
+                }
+            );
+
+            expect(response.url()).toContain('code=');
+            expect(response.url()).toContain('state=' + myState);
+        });
+    });
+
+    test.describe('error path: interceptor grant is denied', () => {
+
+        test.beforeEach(async ({page}) => {
+            const app = new Application(page)
+            test.setTimeout(app.timeout)
+            // Navigating to the interceptor-protected page causes Traefik to
+            // redirect to the login page with mode=interceptor.
+            await app.goto('https://page.ham.test/');
+        });
+
+        test('should show the login page when accessing a protected resource', async ({page}) => {
+            await expect(page).toHaveTitle(/Login/);
+        });
+
+        test('should deny login and show an error when grant type is interceptor', async ({page}) => {
+            const app = new Application(page)
+            await app.auth.login(validUsername, 'secretPassword');
+
+            await expect(page).toHaveURL(/id\.ham\.test\/login/);
+            await expect(page).toHaveTitle(/Login/);
+        });
+
+        test('should allow login for the excepted user via interceptor grant', async ({page, browserName}) => {
+            test.skip(browserName === 'webkit' || browserName === 'mobile-safari', 'WebKit form submission issue');
+            const app = new Application(page)
+            await app.auth.login('allow@example.com', 'secretPassword');
+
+            await expect(page).toHaveTitle('A hilarious ham named Hank');
+        });
+    });
+});

--- a/Tests/e2e/playwright/tests/Interceptor/NoSilentLogin.spec.ts
+++ b/Tests/e2e/playwright/tests/Interceptor/NoSilentLogin.spec.ts
@@ -35,7 +35,7 @@ test.describe('No Silent login to ham', () => {
             await app.goto('https://page.ham.test/')
             await expect(page).toHaveTitle(/Login/)
 
-            await app.auth.login("test@example.com", "test", page)
+            await app.auth.login("allow@example.com", "test", page)
             await expect(page).toHaveTitle("A hilarious ham named Hank")
         })
 

--- a/Tests/e2e/playwright/tests/Pages/Templates.spec.ts
+++ b/Tests/e2e/playwright/tests/Pages/Templates.spec.ts
@@ -36,7 +36,7 @@ test.describe('Templates', () => {
         test.skip(browserName === 'webkit' || browserName === 'mobile-safari', 'WebKit form submission issue');
 
         let response = await app.goto('https://page.ham.test')
-        await app.auth.login('test@example.com', 'test')
+        await app.auth.login('allow@example.com', 'test')
 
         // logout
         const logoutLink = await page.locator('a').getByText('logout')


### PR DESCRIPTION
## Summary

Implements the OAuth 2.0 Device Authorization Grant ([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)) for input-constrained devices such as CLIs, smart TVs, and IoT devices that cannot open a browser directly.

- The device requests a short user code and a verification URI from the authorization server
- The user visits `/activate` on any browser, logs in, and enters the code
- The device polls the `/token` endpoint until the grant is approved

## Changes

### Refactoring (Phase 1)
- **`AuthSession`** refactored from a flat struct to a discriminated union enum (`AuthSession.code`, `.refresh`, `.device`) — each case carries only fields relevant to its flow
- `AuthSession.CodeType` replaced by `AuthSessionType` enum throughout the codebase
- Backward-compatible: existing Redis sessions (`"type": "code"` / `"type": "refresh"`) decode without migration

### Device Grant (Phase 2)
| Area | Detail |
|------|--------|
| Endpoint | `POST /oauth/device_authorization` — issues `device_code`, `user_code`, `verification_uri`, `expires_in`, `interval` |
| Activation | `GET /activate` — enter user code; `POST /activate` — authenticate and approve |
| Token polling | `POST /token` with `grant_type=device_code` — returns `authorization_pending` (428), `slow_down` (429), `access_denied` (400), or tokens (200) |
| Storage | `DeviceSession` in `AuthCodeStorage`; secondary Redis key `deviceuser~{userCode}` for fast lookup by user code |
| Client config | New `device_grant_config` field (`expires_in`, `interval`, `verification_uri`) on `ClientSpec` |
| Well-known | `device_authorization_endpoint` added to OpenID Connect discovery document |
| UI | New `activate.leaf` template; translations in `en_EN`, `de_DE`, `pt_PT` |
| Metrics | 4 new Prometheus counters (`device_flow_initiation`, `device_code_authorized`, `device_code_denied`, `device_code_expired`) |
| CRD | `device_grant_config` schema added to `crd-clients.yaml` |
| E2E | `DeviceGrant.spec.ts` + `DeviceApp` tenant/client fixtures |

## Test plan

- [ ] `./tooling.sh test` — all unit tests pass
- [ ] `./tooling.sh lint` — no violations
- [ ] `curl -X POST .../oauth/device_authorization -d 'client_id=...'` → valid JSON response
- [ ] Navigate to `/activate`, enter user code, log in → success page
- [ ] Poll `/token` with `device_code` → transitions from `authorization_pending` to `200` with tokens
- [ ] `curl .../.well-known/openid-configuration` → contains `device_authorization_endpoint`
- [ ] `./tooling.sh e2e --filter "DeviceGrant"` — all e2e scenarios pass