### PR TITLE
Update soto to 7.x (+ e2e Traefik/core-dump fixes)

### DIFF
--- a/Deployment/e2e/applications/Cheese/04-clients.yaml
+++ b/Deployment/e2e/applications/Cheese/04-clients.yaml
@@ -93,3 +93,23 @@ spec:
     - authorization_code
   referrers:
     - https://spa.example.net/.*
+
+---
+apiVersion: "uitsmijter.io/v1"
+kind: Client
+metadata:
+  name: cheese-secret-client
+  namespace: cheese
+spec:
+  ident: 7b1c9e63-2f8a-4d11-9f3e-5a8c2d4b6e90
+  tenantname: cheese/cheese
+  redirect_urls:
+    - 'https?://api\.example\.com(:8080)?/.*'
+  grant_types:
+    - password
+    - authorization_code
+    - refresh_token
+  scopes:
+    - access
+  # use only test secrets: https://docs.uitsmijter.io/contribution/guidelines/#using-test-secrets-for-development
+  secret: Phai0ohG7zaJ2eech4ohch5ouV9aiwoo3ueRoongei

--- a/Deployment/tooling/includes/kind.fns.sh
+++ b/Deployment/tooling/includes/kind.fns.sh
@@ -260,7 +260,9 @@ function kindSetupCert() {
 function kindSetupTraefik() {
   helm repo add traefik https://traefik.github.io/charts
   helm repo update
-  helm upgrade --install traefik --namespace traefik --create-namespace -f "${PROJECT_DIR}/Deployment/e2e/traefik/values.yaml" traefik/traefik
+  # Pin the chart version: Deployment/e2e/traefik/values.yaml tracks the 38.x values schema.
+  # Newer charts (39.x+) changed the values schema and reject this file. See TRAEFIK_CHART_VERSION.
+  helm upgrade --install traefik --namespace traefik --create-namespace --version "${TRAEFIK_CHART_VERSION:-38.0.2}" -f "${PROJECT_DIR}/Deployment/e2e/traefik/values.yaml" traefik/traefik
   
   kindWaitForPods traefik app.kubernetes.io/instance=traefik-traefik
   kubectl apply \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "7e4848449d842cb4c51e022f60ce7756a12e85152c9177100d630fffab4ac0d1",
+  "originHash" : "19180c8eebdb4129621bce857af46667537255148f7a35753c44dabe8651ccbb",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "8430dd49d4e2b417f472141805c9691ec2923cb8",
-        "version" : "1.29.0"
+        "revision" : "c464bf94eac4273cad7424307a5dc7e44e361905",
+        "version" : "1.30.1"
       }
     },
     {
@@ -58,7 +58,7 @@
     {
       "identity" : "jmespath.swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/adam-fowler/jmespath.swift.git",
+      "location" : "https://github.com/jmespath/jmespath.swift.git",
       "state" : {
         "revision" : "3877a5060e85ae33e3b9fe51ab581784f65ec80e",
         "version" : "1.0.3"
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto.git",
       "state" : {
-        "revision" : "c28c3efa72e6beceae6f38f8c8fe18e7c57e3418",
-        "version" : "6.8.0"
+        "revision" : "f732b562bb5e0202470157a6041aa754229e777e",
+        "version" : "7.14.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-core.git",
       "state" : {
-        "revision" : "3ed66ec536bc372360d7e3ec39a5e8b1870747ea",
-        "version" : "6.5.2"
+        "revision" : "47454bf79649691da406978ae803b51b54246d6e",
+        "version" : "7.14.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
             .package(url: "https://github.com/aus-der-Technik/JXKit.git", branch: "main"),
             .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMajor(from: "1.9.0")),
             .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.1"),
-            .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
+            .package(url: "https://github.com/soto-project/soto.git", from: "7.0.0"),
             .package(url: "https://github.com/swiftkube/client.git", from: "0.15.0"),
             .package(url: "https://github.com/aus-der-Technik/FileMonitor.git", from: "1.2.1"),
             .package(url: "https://github.com/DimaRU/PackageBuildInfo", from: "1.0.4"),

--- a/Sources/Uitsmijter-AuthServer/Entities/ResourceLoader/TenantTemplateLoader.swift
+++ b/Sources/Uitsmijter-AuthServer/Entities/ResourceLoader/TenantTemplateLoader.swift
@@ -190,15 +190,16 @@ actor TenantTemplateLoader {
                 accessKeyId: templates.access_key_id,
                 secretAccessKey: templates.secret_access_key
             ),
-            httpClientProvider: .createNew,
             logger: Log.shared
         )
 
         defer {
-            do {
-                try client.syncShutdown()
-            } catch let err {
-                Log.error("S3 client was unable to shut down: \(err) (\(err.localizedDescription))")
+            Task { [client] in
+                do {
+                    try await client.shutdown()
+                } catch let err {
+                    Log.error("S3 client was unable to shut down: \(err) (\(err.localizedDescription))")
+                }
             }
         }
 
@@ -233,7 +234,9 @@ actor TenantTemplateLoader {
             Log.debug("Creating S3 template directory: \(tenantDir.path)")
             do {
                 let response: S3.GetObjectOutput = try await s3.getObject(fileRequest)
-                guard let content = response.body?.asString() else {
+                let buffer = try await response.body.collect(upTo: 10 * 1024 * 1024)
+                guard let content = buffer.getString(at: buffer.readerIndex, length: buffer.readableBytes),
+                      !content.isEmpty else {
                     Log.warning("S3 object \(s3Debug)/\(file) has no content")
                     continue
                 }

--- a/Tests/e2e/playwright/.gitignore
+++ b/Tests/e2e/playwright/.gitignore
@@ -3,3 +3,6 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+# Crash core dumps left behind by browser crashes (e.g. WebKit minibrowser)
+core
+core.*

--- a/Tests/e2e/playwright/tests/OAuth/AuthorizeRequests.ts
+++ b/Tests/e2e/playwright/tests/OAuth/AuthorizeRequests.ts
@@ -49,10 +49,15 @@ export async function loginAuthorizeFormRequest(page: Page, url: string, data: A
     const queryParams: Record<string, string> = {
         response_type: data.response_type,
         client_id: data.client_id,
-        client_secret: data.client_secret || "null",
         redirect_uri: data.redirect_uri,
         scope: data.scope,
         state: data.state
+    }
+
+    // Only forward client_secret when actually provided — sending the literal
+    // string "null" is rejected by the server for clients that have a secret.
+    if (data.client_secret) {
+        queryParams.client_secret = data.client_secret
     }
 
     // Add optional PKCE parameters if provided

--- a/Tests/e2e/playwright/tests/OAuth/ClientSecretValidation.spec.ts
+++ b/Tests/e2e/playwright/tests/OAuth/ClientSecretValidation.spec.ts
@@ -1,0 +1,228 @@
+import {test, expect} from '@playwright/test';
+import {Application} from "../Fixtures/app";
+import {
+    getTokenForAuthorisationCode,
+    getTokenInfo,
+    loginAuthorizeFormRequest
+} from "./AuthorizeRequests";
+
+// Client `cheese-secret-client` is dedicated to client_secret validation
+// tests (see Deployment/e2e/applications/Cheese/04-clients.yaml). It has a
+// secret and allows the password, authorization_code and refresh_token
+// grants — useful for exercising client_secret enforcement on every grant
+// type that supports it. The password grant intentionally does not issue a
+// refresh_token (see TokenController+TokenGrantTypeRequestHandler.swift), so
+// the password happy path only asserts on the access_token.
+const authUrl = 'https://id.example.com';
+const clientId = '7b1c9e63-2f8a-4d11-9f3e-5a8c2d4b6e90';
+const clientSecret = 'Phai0ohG7zaJ2eech4ohch5ouV9aiwoo3ueRoongei';
+const redirectUri = 'https://api.example.com/';
+const username = 'cee8Esh5@example.com';
+const password = 'secretPassword';
+
+test.describe('client_secret validation', () => {
+
+    test.beforeEach(async ({page}) => {
+        const app = new Application(page)
+        test.setTimeout(app.timeout)
+    });
+
+    test.describe('password grant on /token', () => {
+        test.describe.configure({mode: 'serial'});
+
+        let accessToken: string = null
+
+        test('issues a token when the correct client_secret is provided', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "password",
+                    "client_id": clientId,
+                    "client_secret": clientSecret,
+                    "scope": "access",
+                    "username": username,
+                    "password": password,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(200);
+
+            const jsonResponse = await tokenResponse.json();
+            expect(jsonResponse).toHaveProperty('access_token')
+            expect(jsonResponse).toHaveProperty('expires_in')
+            expect(jsonResponse).toHaveProperty('token_type')
+            expect(jsonResponse.scope).toContain('access')
+
+            accessToken = jsonResponse.access_token;
+        });
+
+        test('accepts the issued access token on the userinfo endpoint', async () => {
+            const tokenInfoResponse = await getTokenInfo(authUrl, accessToken);
+            expect(tokenInfoResponse.status()).toBe(200);
+
+            const jsonResponse = await tokenInfoResponse.json();
+            expect(jsonResponse).toHaveProperty('name')
+        });
+
+        test('rejects the request when client_secret is missing', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "password",
+                    "client_id": clientId,
+                    "scope": "access",
+                    "username": username,
+                    "password": password,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(401);
+        });
+
+        test('rejects the request when client_secret is wrong', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "password",
+                    "client_id": clientId,
+                    "client_secret": "this-is-not-the-secret",
+                    "scope": "access",
+                    "username": username,
+                    "password": password,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(401);
+        });
+    });
+
+    test.describe('authorization_code grant', () => {
+        test.describe.configure({mode: 'serial'});
+
+        const myState = Math.floor(Math.random() * 999999999);
+        let code: string = null
+        let accessToken: string = null
+        let refreshToken: string = null
+
+        test('returns a code after login when the correct client_secret is provided on /authorize', async ({page}) => {
+            const response = await loginAuthorizeFormRequest(
+                page,
+                authUrl,
+                {
+                    client_id: clientId,
+                    client_secret: clientSecret,
+                    redirect_uri: redirectUri,
+                    response_type: "code",
+                    scope: "access",
+                    state: "" + myState,
+                    username: username
+                }
+            );
+
+            expect(response.url()).toContain("state=" + myState)
+            expect(response.url()).toContain("code=");
+            code = response.url().match(/code=(.+)&/)[1];
+            expect(code.length).toBeGreaterThan(0);
+        });
+
+        test('exchanges the code for a token when the correct client_secret is provided on /token', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "authorization_code",
+                    "client_id": clientId,
+                    "client_secret": clientSecret,
+                    "scope": "access",
+                    "code": "" + code,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(200);
+
+            const jsonResponse = await tokenResponse.json();
+            expect(jsonResponse).toHaveProperty('access_token')
+            expect(jsonResponse).toHaveProperty('refresh_token')
+            expect(jsonResponse).toHaveProperty('expires_in')
+            expect(jsonResponse.scope).toContain('access')
+
+            accessToken = jsonResponse.access_token;
+            refreshToken = jsonResponse.refresh_token;
+        });
+
+        test('refreshes the token when the correct client_secret is provided on /token', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "refresh_token",
+                    "client_id": clientId,
+                    "client_secret": clientSecret,
+                    "refresh_token": refreshToken,
+                },
+                accessToken
+            );
+
+            expect(tokenResponse.status()).toBe(200);
+
+            const jsonResponse = await tokenResponse.json();
+            expect(jsonResponse).toHaveProperty('access_token')
+            expect(jsonResponse).toHaveProperty('refresh_token')
+            expect(jsonResponse.access_token).not.toBe(accessToken)
+        });
+    });
+
+    test.describe('authorization_code grant - error cases', () => {
+        test.describe.configure({mode: 'serial'});
+
+        const myState = Math.floor(Math.random() * 999999999);
+        let code: string = null
+
+        test('returns a code so the token-exchange error cases have something to send', async ({page}) => {
+            const response = await loginAuthorizeFormRequest(
+                page,
+                authUrl,
+                {
+                    client_id: clientId,
+                    client_secret: clientSecret,
+                    redirect_uri: redirectUri,
+                    response_type: "code",
+                    scope: "access",
+                    state: "" + myState,
+                    username: username
+                }
+            );
+
+            expect(response.url()).toContain("code=");
+            code = response.url().match(/code=(.+)&/)[1];
+            expect(code.length).toBeGreaterThan(0);
+        });
+
+        test('rejects the token exchange when client_secret is missing', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "authorization_code",
+                    "client_id": clientId,
+                    "scope": "access",
+                    "code": "" + code,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(401);
+        });
+
+        test('rejects the token exchange when client_secret is wrong', async () => {
+            const tokenResponse = await getTokenForAuthorisationCode(
+                authUrl,
+                {
+                    "grant_type": "authorization_code",
+                    "client_id": clientId,
+                    "client_secret": "this-is-not-the-secret",
+                    "scope": "access",
+                    "code": "" + code,
+                }
+            );
+
+            expect(tokenResponse.status()).toBe(401);
+        });
+    });
+});

--- a/Tests/e2e/playwright/tests/types/TokenRequestData.d.ts
+++ b/Tests/e2e/playwright/tests/types/TokenRequestData.d.ts
@@ -1,6 +1,7 @@
 export interface TokenRequestData {
     grant_type: "authorization_code" | "refresh_token" | "password"
     client_id: string
+    client_secret?: string,
     scope?: string,
     code?: string,
     refresh_token?: string


### PR DESCRIPTION
## Summary

Updates the soto AWS SDK from 6.x to 7.x and fixes two unrelated e2e/tooling breakages found along the way.

### soto 6.x → 7.14.0
- Bumps soto `6.0.0` → **7.14.0**, soto-core → **7.14.0**, async-http-client `1.29.0` → **1.30.1** (soto-core 7.14 requires AHC ≥1.30). soto 7 also enables the `ServiceLifecycleSupport` package trait, which requires a trait-aware soto-core.
- Migrates `TenantTemplateLoader` to the soto 7 API:
  - `AWSClient` no longer takes `httpClientProvider`; it now defaults to the shared `HTTPClient`. Shutdown moved from `syncShutdown()` to the async `shutdown()`.
  - `S3.GetObjectOutput.body` is now a non-optional streaming `AWSHTTPBody`; read it via `collect(upTo:)` and decode the resulting `ByteBuffer`.

### e2e: pin Traefik Helm chart to 38.0.2
The e2e Traefik install used an unpinned chart, so `helm repo update` pulled the latest (41.x), whose values schema rejects `Deployment/e2e/traefik/values.yaml`. Pinned to **38.0.2** (appVersion v3.6.6) — the newest chart whose schema still matches the tracked values file — overridable via `TRAEFIK_CHART_VERSION`.

### e2e: ignore browser crash core dumps
A WebKit minibrowser crash during e2e leaves a multi-GB ELF core dump at `Tests/e2e/playwright/core`. The root `.gitignore`'s `/core` is anchored to the repo root and doesn't match it, so added `core`/`core.*` ignores in the playwright test dir.

## Verification
- `swift build` and `swift build --build-tests` — clean (strict Swift 6 concurrency, `-warnings-as-errors`)
- `./tooling.sh lint` — 0 violations
- Traefik chart 38.0.2 schema-validated against the values file via `helm template`
- Not run: full `./tooling.sh e2e` (needs kind cluster) and the S3 template-download path (no test covers it) — the soto migration is compile-verified only.