### PR TITLE
Fix client_secret RFC compliance on /authorize + style device activation success

### DIFF
--- a/Public/css/uitsmijter.css
+++ b/Public/css/uitsmijter.css
@@ -299,6 +299,34 @@ input {
     font-size: .8rem;
 }
 
+/* Device activation success message */
+.login-box .message[data-result="success"] {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 1rem;
+    padding: 2rem 2.5rem;
+    font-size: 1.15rem;
+    line-height: 1.4;
+    color: #3a4a2f;
+}
+
+.login-box .message[data-result="success"]::before {
+    content: "✓";
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 50%;
+    background-color: #6f9a3c;
+    color: white;
+    font-size: 1.9rem;
+    font-weight: 700;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, .15);
+}
+
 @media all and (max-width: 800px) {
     .navigation, .footer-item {
         justify-content: space-around;

--- a/Sources/Uitsmijter-AuthServer/Controllers/AuthorizeController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/AuthorizeController.swift
@@ -259,9 +259,11 @@ struct AuthorizeController: RouteCollection, OAuthControllerProtocol {
         if client.config.isPkceOnly ?? false {
             throw Abort(.badRequest, reason: "LOGIN.ERRORS.CLIENT_ONLY_SUPPORTS_PKCE")
         }
-        if client.config.secret != nil && client.config.secret != authRequest.client_secret {
-            throw Abort(.unauthorized, reason: "LOGIN.ERROR.WRONG_CLIENT_SECRET")
-        }
+        // NOTE: The client secret is deliberately NOT validated here. Per RFC 6749
+        // §3.2.1 / §4.1.1 the authorization endpoint only *identifies* the client
+        // (client_id); confidential clients authenticate with their secret on the
+        // back-channel token request (TokenController). Requiring it here would both
+        // break spec-conformant clients and leak the secret through the user-agent.
         let redirect = try client.checkedRedirect(for: authRequest)
 
         // Filter requested scopes from the authorization request
@@ -341,10 +343,10 @@ struct AuthorizeController: RouteCollection, OAuthControllerProtocol {
             throw Abort(.forbidden, reason: "LOGIN.ERRORS.TENANT_MISMATCH")
         }
 
-        if client.config.secret != nil && client.config.secret != authRequest.client_secret {
-            throw Abort(.unauthorized, reason: "LOGIN.ERROR.WRONG_CLIENT_SECRET")
-        }
-
+        // NOTE: No client secret validation on the authorization endpoint — see the
+        // non-PKCE handler above. The secret is authenticated on the token request
+        // (RFC 6749 §3.2.1 / §4.1.1). PKCE clients in particular are typically public
+        // and carry no secret at all.
         let redirect = try client.checkedRedirect(for: authRequest)
 
         // Filter requested scopes from the authorization request

--- a/Tests/Uitsmijter-AuthServerTests/Controllers/AuthControllerCodeClientWithSecretTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Controllers/AuthControllerCodeClientWithSecretTest.swift
@@ -41,7 +41,7 @@ struct AuthControllerCodeClientWithSecretTest {
         }
     }
 
-    @Test("Code flow no client secret") func codeFlowNoClientSecret() async throws {
+    @Test("Code flow issues a code without client_secret at /authorize") func codeFlowNoClientSecret() async throws {
         try await withApp(configure: configure) { app in
             await generateTestClientWithSecret(in: app.entityStorage, uuid: testAppIdent, secret: testSecret)
             guard let tenant = await app.entityStorage.clients.first(
@@ -64,13 +64,16 @@ struct AuthControllerCodeClientWithSecretTest {
                     req.headers.bearerAuthorization = try await validAuthorisation(for: tenant, in: app)
                 },
                 afterResponse: { @Sendable res async throws in
-                    #expect(res.status == .unauthorized)
+                    // RFC 6749 §4.1.1: the authorization endpoint does not authenticate
+                    // the client secret, so a code is still issued. The secret is enforced
+                    // on the token request.
+                    #expect(res.status == .seeOther)
                 }
             )
         }
     }
 
-    @Test("Code flow wrong client secret") func codeFlowWrongClientSecret() async throws {
+    @Test("Code flow ignores client_secret at /authorize") func codeFlowWrongClientSecret() async throws {
         try await withApp(configure: configure) { app in
             await generateTestClientWithSecret(in: app.entityStorage, uuid: testAppIdent, secret: testSecret)
             guard let tenant = await app.entityStorage.clients
@@ -93,7 +96,10 @@ struct AuthControllerCodeClientWithSecretTest {
                     req.headers.bearerAuthorization = try await validAuthorisation(for: tenant, in: app)
                 },
                 afterResponse: { @Sendable res async throws in
-                    #expect(res.status == .unauthorized)
+                    // RFC 6749 §4.1.1: the authorization endpoint does not authenticate
+                    // the client secret, so a code is still issued. The secret is enforced
+                    // on the token request.
+                    #expect(res.status == .seeOther)
                 }
             )
         }
@@ -132,7 +138,8 @@ struct AuthControllerCodeClientWithSecretTest {
         }
     }
 
-    @Test("Code flow no client secret plain") func codeFlowNoClientSecretPlain() async throws {
+    @Test("Code flow (PKCE) issues a code without client_secret at /authorize")
+    func codeFlowNoClientSecretPlain() async throws {
         try await withApp(configure: configure) { app in
             await generateTestClientWithSecret(in: app.entityStorage, uuid: testAppIdent, secret: testSecret)
             guard let tenant = await app.entityStorage.clients
@@ -156,13 +163,16 @@ struct AuthControllerCodeClientWithSecretTest {
                     req.headers.bearerAuthorization = try await validAuthorisation(for: tenant, in: app)
                 },
                 afterResponse: { @Sendable res async throws in
-                    #expect(res.status == .unauthorized)
+                    // RFC 6749 §4.1.1: the authorization endpoint does not authenticate
+                    // the client secret, so a code is still issued. The secret is enforced
+                    // on the token request.
+                    #expect(res.status == .seeOther)
                 }
             )
         }
     }
 
-    @Test("Code flow wrong client secret plain") func codeFlowWrongClientSecretPlain() async throws {
+    @Test("Code flow (PKCE) ignores client_secret at /authorize") func codeFlowWrongClientSecretPlain() async throws {
         try await withApp(configure: configure) { app in
             await generateTestClientWithSecret(in: app.entityStorage, uuid: testAppIdent, secret: testSecret)
             guard let tenant = await app.entityStorage.clients
@@ -187,7 +197,10 @@ struct AuthControllerCodeClientWithSecretTest {
                     req.headers.bearerAuthorization = try await validAuthorisation(for: tenant, in: app)
                 },
                 afterResponse: { @Sendable res async throws in
-                    #expect(res.status == .unauthorized)
+                    // RFC 6749 §4.1.1: the authorization endpoint does not authenticate
+                    // the client secret, so a code is still issued. The secret is enforced
+                    // on the token request.
+                    #expect(res.status == .seeOther)
                 }
             )
         }

--- a/Tests/e2e/playwright/tests/OAuth/ClientSecretValidation.spec.ts
+++ b/Tests/e2e/playwright/tests/OAuth/ClientSecretValidation.spec.ts
@@ -104,13 +104,15 @@ test.describe('client_secret validation', () => {
         let accessToken: string = null
         let refreshToken: string = null
 
-        test('returns a code after login when the correct client_secret is provided on /authorize', async ({page}) => {
+        // RFC 6749 §4.1.1: the authorization endpoint must not require the client
+        // secret — it is only identified by client_id. The secret is enforced on the
+        // token request below.
+        test('issues a code from /authorize WITHOUT a client_secret', async ({page}) => {
             const response = await loginAuthorizeFormRequest(
                 page,
                 authUrl,
                 {
                     client_id: clientId,
-                    client_secret: clientSecret,
                     redirect_uri: redirectUri,
                     response_type: "code",
                     scope: "access",
@@ -182,7 +184,6 @@ test.describe('client_secret validation', () => {
                 authUrl,
                 {
                     client_id: clientId,
-                    client_secret: clientSecret,
                     redirect_uri: redirectUri,
                     response_type: "code",
                     scope: "access",


### PR DESCRIPTION
## Summary

Two related fixes to the OAuth/device-grant surface.

### 1. Do not require `client_secret` on `/authorize` (RFC 6749)

Users reported that Uitsmijter demands the client secret on **both** the authorization request and the token request, while the RFC wants it only on the latter.

- **RFC 6749 §4.1.1** (Authorization Request) defines no `client_secret` — the authorization endpoint only *identifies* the client via `client_id`.
- **§3.2.1** / **§2.3**: confidential clients authenticate with their secret on the **back-channel token request**. OIDC Core §3.1.2.1 & §9 say the same.

Requiring it on `/authorize` (a) broke spec-conformant clients that never send the secret there, and (b) leaked the secret through the user-agent (browser history, `Referer`, logs).

**Change:** removed the secret check from both `doAuthHandler` overloads in `AuthorizeController` (plain + PKCE). The token endpoint (`TokenController`) still enforces the secret — the sole correct place.

Tests:
- Unit (`AuthControllerCodeClientWithSecretTest`): `/authorize` now issues a code with a missing/wrong secret; token-endpoint enforcement unchanged.
- E2E (`ClientSecretValidation.spec.ts`): `/authorize` succeeds without the secret; `/token` still rejects missing/wrong secret (401).

### 2. Style the device activation success message

The "device authorized successfully" page rendered as plain left-aligned text in a bare white box. Now it shows a centered layout with a success checkmark badge, scoped to the activate success state (the login page message is untouched).

## Verification

- `swift build` clean; controller test suites **71/71 pass**; `./tooling.sh lint` **0 violations**.
- Activation page rendered in Chrome to confirm the new look.
- Not run: full e2e suite (needs a kind cluster).