### PR TITLE
Pass tenant context (name/id) to JavaScript providers

### DIFF
--- a/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
@@ -170,7 +170,8 @@ struct ActivateController: RouteCollection {
             arguments: JSInputCredentials(
                 username: username,
                 password: password,
-                grantType: .device_code
+                grantType: .device_code,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
@@ -271,7 +271,12 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
         try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
         try await providerInterpreter.start(
             class: .userLogin,
-            arguments: JSInputCredentials(username: form.username, password: form.password, grantType: grantType)
+            arguments: JSInputCredentials(
+                username: form.username,
+                password: form.password,
+                grantType: grantType,
+                tenant: JSInputTenant(from: tenant)
+            )
         )
         return providerInterpreter
     }

--- a/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
@@ -222,7 +222,8 @@ extension TokenController {
             arguments: JSInputCredentials(
                 username: passwordTokenRequest.username,
                 password: passwordTokenRequest.password,
-                grantType: .password
+                grantType: .password,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
+++ b/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
@@ -117,7 +117,8 @@ struct UserValidation {
         try await providerInterpreter.start(
             class: .userValidate,
             arguments: JSInputUsername(
-                username: username
+                username: username,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
@@ -9,10 +9,13 @@ struct JSInputCredentials: JSInputParameterProtocol, Sendable {
     let password: String
     /// The OAuth2 grant type used for this authentication request
     let grantType: GrantTypes
+    /// The tenant this authentication request belongs to
+    let tenant: JSInputTenant
 
     enum CodingKeys: String, CodingKey {
         case username
         case password
         case grantType = "grant_type"
+        case tenant
     }
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
@@ -10,33 +10,39 @@ import Foundation
 /// class UserLoginProvider {
 ///   constructor(credentials) {
 ///     const tenantName = credentials.tenant.name;
-///     const tenantId = credentials.tenant.id; // null for file-based tenants
+///     const tenantNamespace = credentials.tenant.namespace; // null for file-based tenants
 ///     // … call the external user service scoped to this tenant …
 ///   }
 /// }
 /// ```
 struct JSInputTenant: Codable, Sendable {
-    /// The tenant's unique name (always present).
+    /// The tenant's name (without the namespace prefix).
     let name: String
 
-    /// The tenant's resource identifier. This is the Kubernetes CRD UID when the
-    /// tenant is loaded from a CRD, and `nil` for file-based tenants (which have
-    /// no stable id — identify those by ``name``).
-    let id: String?
+    /// The Kubernetes namespace the tenant is defined in.
+    ///
+    /// `nil` for file-based tenants, which have no namespace. CRD tenants are stored
+    /// internally as `"<namespace>/<name>"`; this splits that back into its parts.
+    let namespace: String?
 
     /// Create the tenant context from explicit values.
-    init(name: String, id: String? = nil) {
+    init(name: String, namespace: String? = nil) {
         self.name = name
-        self.id = id
+        self.namespace = namespace
     }
 
     /// Build the tenant context from a loaded ``Tenant``.
+    ///
+    /// CRD tenants carry a `"<namespace>/<name>"` name; file-based tenants carry a
+    /// plain name and therefore have no namespace.
     init(from tenant: Tenant) {
-        self.name = tenant.name
-        if case .kubernetes(let uuid, _) = tenant.ref {
-            self.id = uuid.uuidString
+        let parts = tenant.name.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        if parts.count == 2 {
+            self.namespace = String(parts[0])
+            self.name = String(parts[1])
         } else {
-            self.id = nil
+            self.namespace = nil
+            self.name = tenant.name
         }
     }
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Tenant context passed into the JavaScript provider alongside the credentials.
+///
+/// Exposed to provider scripts as the `tenant` property of the constructor argument,
+/// so a provider (e.g. one talking to Uitrusting) can scope its request to the
+/// correct tenant:
+///
+/// ```javascript
+/// class UserLoginProvider {
+///   constructor(credentials) {
+///     const tenantName = credentials.tenant.name;
+///     const tenantId = credentials.tenant.id; // null for file-based tenants
+///     // … call the external user service scoped to this tenant …
+///   }
+/// }
+/// ```
+struct JSInputTenant: Codable, Sendable {
+    /// The tenant's unique name (always present).
+    let name: String
+
+    /// The tenant's resource identifier. This is the Kubernetes CRD UID when the
+    /// tenant is loaded from a CRD, and `nil` for file-based tenants (which have
+    /// no stable id — identify those by ``name``).
+    let id: String?
+
+    /// Create the tenant context from explicit values.
+    init(name: String, id: String? = nil) {
+        self.name = name
+        self.id = id
+    }
+
+    /// Build the tenant context from a loaded ``Tenant``.
+    init(from tenant: Tenant) {
+        self.name = tenant.name
+        if case .kubernetes(let uuid, _) = tenant.ref {
+            self.id = uuid.uuidString
+        } else {
+            self.id = nil
+        }
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputUsername.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputUsername.swift
@@ -5,4 +5,6 @@ import Foundation
 struct JSInputUsername: JSInputParameterProtocol, Sendable {
     /// Users username or email address
     let username: String
+    /// The tenant this validation request belongs to
+    let tenant: JSInputTenant
 }

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Uitsmijter_AuthServer
 
+// swiftlint:disable type_body_length
 @Suite("JavaScript Functions Networking Tests")
 struct JSFunctionsNetworkingTest {
 
@@ -279,7 +280,8 @@ struct JSFunctionsNetworkingTest {
         """)
 
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "test", grantType: .authorization_code
+            username: "test@example.com", password: "test", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let results = try await jsp.start(class: .userLogin, arguments: credentials)
 

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
@@ -2,6 +2,7 @@ import Testing
 @testable import Uitsmijter_AuthServer
 import Foundation
 
+// swiftlint:disable type_body_length
 @Suite("JSInputParameter Protocol Tests")
 struct JSInputParameterTest {
 
@@ -9,13 +10,13 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername initializes with username")
     func jsInputUsernameInitialization() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         #expect(username.username == "test@example.com")
     }
 
     @Test("JSInputUsername toJSON produces valid JSON")
     func jsInputUsernameToJSON() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -25,15 +26,22 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername toJSON format is correct")
     func jsInputUsernameJSONFormat() throws {
-        let username = JSInputUsername(username: "user@test.com")
+        let username = JSInputUsername(username: "user@test.com", tenant: JSInputTenant(name: "acme"))
         let json = try username.toJSON()
 
-        #expect(json == "{\"username\":\"user@test.com\"}")
+        // Decode rather than match an exact string (JSON key order is not guaranteed).
+        guard let data = json?.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(JSInputUsername.self, from: data) else {
+            Issue.record("Failed to parse JSON output")
+            return
+        }
+        #expect(parsed.username == "user@test.com")
+        #expect(parsed.tenant.name == "acme")
     }
 
     @Test("JSInputUsername encodes to JSON with special characters")
     func jsInputUsernameWithSpecialChars() throws {
-        let username = JSInputUsername(username: "test+user@example.com")
+        let username = JSInputUsername(username: "test+user@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json?.contains("test+user@example.com") == true)
@@ -41,7 +49,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername encodes to JSON with unicode")
     func jsInputUsernameWithUnicode() throws {
-        let username = JSInputUsername(username: "用户@example.com")
+        let username = JSInputUsername(username: "用户@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -50,25 +58,27 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername encodes empty string")
     func jsInputUsernameEmpty() throws {
-        let username = JSInputUsername(username: "")
+        let username = JSInputUsername(username: "", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
-        #expect(json == "{\"username\":\"\"}")
+        #expect(json?.contains("\"username\":\"\"") == true)
     }
 
     @Test("JSInputUsername decodes from JSON")
     func jsInputUsernameDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com"}
+        {"username":"decoded@example.com","tenant":{"name":"acme","id":"xyz"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
+        #expect(decoded.tenant.name == "acme")
+        #expect(decoded.tenant.id == "xyz")
     }
 
     @Test("JSInputUsername round-trip encoding and decoding")
     func jsInputUsernameRoundTrip() throws {
-        let original = JSInputUsername(username: "roundtrip@test.com")
+        let original = JSInputUsername(username: "roundtrip@test.com", tenant: JSInputTenant(name: "test"))
         let json = try original.toJSON()
 
         guard let jsonString = json else {
@@ -86,7 +96,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials initializes with username and password")
     func jsInputCredentialsInitialization() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "secret123", grantType: .authorization_code
+            username: "user@test.com", password: "secret123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         #expect(credentials.username == "user@test.com")
         #expect(credentials.password == "secret123")
@@ -96,7 +107,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials toJSON produces valid JSON")
     func jsInputCredentialsToJSON() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "pass123", grantType: .authorization_code
+            username: "user@test.com", password: "pass123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -112,7 +124,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials toJSON format is correct")
     func jsInputCredentialsJSONFormat() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "mypass", grantType: .authorization_code
+            username: "user@test.com", password: "mypass", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -130,7 +143,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials encodes with special characters")
     func jsInputCredentialsWithSpecialChars() throws {
         let credentials = JSInputCredentials(
-            username: "test+user@example.com", password: "p@ss!word#123", grantType: .authorization_code
+            username: "test+user@example.com", password: "p@ss!word#123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -140,7 +154,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty password")
     func jsInputCredentialsEmptyPassword() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "", grantType: .authorization_code)
+        let credentials = JSInputCredentials(username: "user@test.com", password: "", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test"))
         let json = try credentials.toJSON()
 
         #expect(json?.contains("user@test.com") == true)
@@ -149,7 +164,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty username")
     func jsInputCredentialsEmptyUsername() throws {
-        let credentials = JSInputCredentials(username: "", password: "password", grantType: .authorization_code)
+        let credentials = JSInputCredentials(username: "", password: "password", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test"))
         let json = try credentials.toJSON()
 
         #expect(json?.contains("username") == true)
@@ -159,7 +175,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials encodes with unicode")
     func jsInputCredentialsWithUnicode() throws {
         let credentials = JSInputCredentials(
-            username: "用户@example.com", password: "密码123", grantType: .authorization_code
+            username: "用户@example.com", password: "密码123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -170,19 +187,22 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials decodes from JSON")
     func jsInputCredentialsDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com","password":"decodedpass","grant_type":"authorization_code"}
+        {"username":"decoded@example.com","password":"decodedpass",\
+        "grant_type":"authorization_code","tenant":{"name":"acme"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
         #expect(decoded.password == "decodedpass")
         #expect(decoded.grantType == .authorization_code)
+        #expect(decoded.tenant.name == "acme")
     }
 
     @Test("JSInputCredentials round-trip encoding and decoding")
     func jsInputCredentialsRoundTrip() throws {
         let original = JSInputCredentials(
-            username: "roundtrip@test.com", password: "roundtrippass", grantType: .password
+            username: "roundtrip@test.com", password: "roundtrippass", grantType: .password,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try original.toJSON()
 
@@ -202,7 +222,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to JSInputParameterProtocol")
     func jsInputUsernameConformsToProtocol() throws {
-        let username: any JSInputParameterProtocol = JSInputUsername(username: "test@example.com")
+        let username: any JSInputParameterProtocol = JSInputUsername(username: "test@example.com",
+            tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -213,7 +234,7 @@ struct JSInputParameterTest {
         let credentials: any JSInputParameterProtocol = JSInputCredentials(
             username: "test@example.com",
             password: "password",
-            grantType: .authorization_code
+            grantType: .authorization_code, tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -222,7 +243,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to Codable")
     func jsInputUsernameConformsToCodable() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         let encoded = try JSONEncoder().encode(username)
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: encoded)
 
@@ -232,7 +253,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials conforms to Codable")
     func jsInputCredentialsConformsToCodable() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "password", grantType: .interceptor
+            username: "test@example.com", password: "password", grantType: .interceptor,
+            tenant: JSInputTenant(name: "test")
         )
         let encoded = try JSONEncoder().encode(credentials)
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: encoded)
@@ -244,7 +266,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to Sendable")
     func jsInputUsernameConformsToSendable() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
 
         // Sendable conformance is compile-time checked
         // This test verifies it can be used in async contexts
@@ -258,7 +280,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials conforms to Sendable")
     func jsInputCredentialsConformsToSendable() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "password", grantType: .authorization_code
+            username: "test@example.com", password: "password", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
 
         // Sendable conformance is compile-time checked
@@ -276,7 +299,7 @@ struct JSInputParameterTest {
     @Test("JSInputUsername with very long username")
     func jsInputUsernameVeryLong() throws {
         let longUsername = String(repeating: "a", count: 1000) + "@example.com"
-        let username = JSInputUsername(username: longUsername)
+        let username = JSInputUsername(username: longUsername, tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -287,7 +310,8 @@ struct JSInputParameterTest {
     func jsInputCredentialsVeryLongPassword() throws {
         let longPassword = String(repeating: "x", count: 1000)
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: longPassword, grantType: .authorization_code
+            username: "test@example.com", password: longPassword, grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -298,7 +322,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials with newlines in password")
     func jsInputCredentialsWithNewlines() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "pass\nword", grantType: .authorization_code
+            username: "test@example.com", password: "pass\nword", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -309,7 +334,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername with quotes in username")
     func jsInputUsernameWithQuotes() throws {
-        let username = JSInputUsername(username: "test\"user@example.com")
+        let username = JSInputUsername(username: "test\"user@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -320,7 +345,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials with backslashes")
     func jsInputCredentialsWithBackslashes() throws {
         let credentials = JSInputCredentials(
-            username: "test\\user@example.com", password: "pass\\word", grantType: .authorization_code
+            username: "test\\user@example.com", password: "pass\\word", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
@@ -67,13 +67,13 @@ struct JSInputParameterTest {
     @Test("JSInputUsername decodes from JSON")
     func jsInputUsernameDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com","tenant":{"name":"acme","id":"xyz"}}
+        {"username":"decoded@example.com","tenant":{"name":"acme","namespace":"acme-ns"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
         #expect(decoded.tenant.name == "acme")
-        #expect(decoded.tenant.id == "xyz")
+        #expect(decoded.tenant.namespace == "acme-ns")
     }
 
     @Test("JSInputUsername round-trip encoding and decoding")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
@@ -5,7 +5,8 @@ import Testing
 @Suite("JavaScript Provider Get Properties Tests")
 struct JavaScriptProviderGetPropertiesTest {
     let dummyCredentials = JSInputCredentials(
-        username: "test@example.com", password: "test", grantType: .authorization_code
+        username: "test@example.com", password: "test", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     @Test("getSubject returns committed subject from script")
     func getSubjectReturnsCommittedSubject() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
@@ -7,7 +7,8 @@ import Testing
 struct JavaScriptProviderTest {
 
     let dummyCredentials = JSInputCredentials(
-        username: "test@example.com", password: "test", grantType: .authorization_code
+        username: "test@example.com", password: "test", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("JavaScriptProvider initializes successfully")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
@@ -32,10 +32,12 @@ struct UserLoginCommittedSubjectTest {
                                      """
 
     let userOK = JSInputCredentials(
-        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     let userDenied = JSInputCredentials(
-        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("Get committed value can login")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
@@ -36,10 +36,12 @@ struct UserLoginProviderTests {
                                      """
 
     let userOK = JSInputCredentials(
-        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     let userDenied = JSInputCredentials(
-        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("Get example with callback")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import Uitsmijter_AuthServer
+
+@Suite("User Login Tenant Context Tests")
+struct UserLoginTenantContextTest {
+
+    /// Provider that echoes the tenant context it received back as the subject,
+    /// so the test can assert the tenant name/id are passed into the JS context.
+    let providerEchoTenant = """
+                             class UserLoginProvider {
+                                constructor(credentials) {
+                                    const t = credentials.tenant;
+                                    return commit({ subject: t.name + ":" + (t.id || "none") });
+                                }
+                                get canLogin() { return true; }
+                                get userProfile() { return {}; }
+                             }
+                             """
+
+    @Test("Provider receives tenant name and id")
+    func providerReceivesTenantNameAndId() async throws {
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: providerEchoTenant)
+
+        let credentials = JSInputCredentials(
+            username: "user@example.com",
+            password: "secret",
+            grantType: .authorization_code,
+            tenant: JSInputTenant(name: "acme", id: "abc-123")
+        )
+        let committed = try await provider.start(class: .userLogin, arguments: credentials)
+
+        let subjects = Subject.decode(from: committed.compactMap({ $0 }))
+        #expect(subjects.first?.subject == "acme:abc-123")
+    }
+
+    @Test("Provider receives tenant name with nil id for file-based tenants")
+    func providerReceivesTenantNameWithoutId() async throws {
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: providerEchoTenant)
+
+        let credentials = JSInputCredentials(
+            username: "user@example.com",
+            password: "secret",
+            grantType: .authorization_code,
+            tenant: JSInputTenant(name: "acme")
+        )
+        let committed = try await provider.start(class: .userLogin, arguments: credentials)
+
+        let subjects = Subject.decode(from: committed.compactMap({ $0 }))
+        #expect(subjects.first?.subject == "acme:none")
+    }
+
+    @Test("JSInputTenant derives id from a Kubernetes tenant reference")
+    func tenantContextFromKubernetesRef() throws {
+        let uuid = UUID()
+        let tenant = Tenant(
+            ref: .kubernetes(uuid, "rev-1"),
+            name: "k8s-tenant",
+            config: TenantSpec(hosts: ["localhost"])
+        )
+        let context = JSInputTenant(from: tenant)
+        #expect(context.name == "k8s-tenant")
+        #expect(context.id == uuid.uuidString)
+    }
+
+    @Test("JSInputTenant has no id for a file-based tenant reference")
+    func tenantContextFromFileRef() throws {
+        let tenant = Tenant(
+            ref: .file(URL(fileURLWithPath: "/tmp/tenant.yaml")),
+            name: "file-tenant",
+            config: TenantSpec(hosts: ["localhost"])
+        )
+        let context = JSInputTenant(from: tenant)
+        #expect(context.name == "file-tenant")
+        #expect(context.id == nil)
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
@@ -6,20 +6,20 @@ import Testing
 struct UserLoginTenantContextTest {
 
     /// Provider that echoes the tenant context it received back as the subject,
-    /// so the test can assert the tenant name/id are passed into the JS context.
+    /// so the test can assert the tenant name/namespace are passed into the JS context.
     let providerEchoTenant = """
                              class UserLoginProvider {
                                 constructor(credentials) {
                                     const t = credentials.tenant;
-                                    return commit({ subject: t.name + ":" + (t.id || "none") });
+                                    return commit({ subject: t.name + ":" + (t.namespace || "none") });
                                 }
                                 get canLogin() { return true; }
                                 get userProfile() { return {}; }
                              }
                              """
 
-    @Test("Provider receives tenant name and id")
-    func providerReceivesTenantNameAndId() async throws {
+    @Test("Provider receives tenant name and namespace")
+    func providerReceivesTenantNameAndNamespace() async throws {
         let provider = JavaScriptProvider()
         try await provider.loadProvider(script: providerEchoTenant)
 
@@ -27,16 +27,16 @@ struct UserLoginTenantContextTest {
             username: "user@example.com",
             password: "secret",
             grantType: .authorization_code,
-            tenant: JSInputTenant(name: "acme", id: "abc-123")
+            tenant: JSInputTenant(name: "acme", namespace: "littleletter-uitsmijter")
         )
         let committed = try await provider.start(class: .userLogin, arguments: credentials)
 
         let subjects = Subject.decode(from: committed.compactMap({ $0 }))
-        #expect(subjects.first?.subject == "acme:abc-123")
+        #expect(subjects.first?.subject == "acme:littleletter-uitsmijter")
     }
 
-    @Test("Provider receives tenant name with nil id for file-based tenants")
-    func providerReceivesTenantNameWithoutId() async throws {
+    @Test("Provider receives tenant name with nil namespace for file-based tenants")
+    func providerReceivesTenantNameWithoutNamespace() async throws {
         let provider = JavaScriptProvider()
         try await provider.loadProvider(script: providerEchoTenant)
 
@@ -52,21 +52,21 @@ struct UserLoginTenantContextTest {
         #expect(subjects.first?.subject == "acme:none")
     }
 
-    @Test("JSInputTenant derives id from a Kubernetes tenant reference")
-    func tenantContextFromKubernetesRef() throws {
-        let uuid = UUID()
+    @Test("JSInputTenant splits namespace and name from a CRD tenant")
+    func tenantContextFromKubernetesTenant() throws {
+        // CRD tenants are stored internally as "<namespace>/<name>".
         let tenant = Tenant(
-            ref: .kubernetes(uuid, "rev-1"),
-            name: "k8s-tenant",
+            ref: .kubernetes(UUID(), "rev-1"),
+            name: "littleletter-uitsmijter/acme",
             config: TenantSpec(hosts: ["localhost"])
         )
         let context = JSInputTenant(from: tenant)
-        #expect(context.name == "k8s-tenant")
-        #expect(context.id == uuid.uuidString)
+        #expect(context.name == "acme")
+        #expect(context.namespace == "littleletter-uitsmijter")
     }
 
-    @Test("JSInputTenant has no id for a file-based tenant reference")
-    func tenantContextFromFileRef() throws {
+    @Test("JSInputTenant has no namespace for a file-based tenant")
+    func tenantContextFromFileTenant() throws {
         let tenant = Tenant(
             ref: .file(URL(fileURLWithPath: "/tmp/tenant.yaml")),
             name: "file-tenant",
@@ -74,6 +74,6 @@ struct UserLoginTenantContextTest {
         )
         let context = JSInputTenant(from: tenant)
         #expect(context.name == "file-tenant")
-        #expect(context.id == nil)
+        #expect(context.namespace == nil)
     }
 }

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserValidationProviderTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserValidationProviderTests.swift
@@ -23,8 +23,8 @@ struct UserValidationProviderTests {
                          }
                          """
 
-    let userOK = JSInputUsername(username: "ok@example.com")
-    let userDenied = JSInputUsername(username: "deni@example.com")
+    let userOK = JSInputUsername(username: "ok@example.com", tenant: JSInputTenant(name: "test"))
+    let userDenied = JSInputUsername(username: "deni@example.com", tenant: JSInputTenant(name: "test"))
 
     @Test("Get example with callback")
     func getExampleCallback() async throws {


### PR DESCRIPTION
## Summary

Tenant JavaScript providers (`UserLoginProvider` / `UserValidationProvider`) previously received only the username/password. That is not enough to talk to an external, multi-tenant user service such as **Uitrusting**, whose API is scoped by tenant (e.g. `/tenants/{tenantId}/users`). This PR exposes the tenant to the provider script.

## What changed

The constructor argument now carries a nested `tenant` object:

```javascript
class UserLoginProvider {
  constructor(credentials) {
    const tenantName = credentials.tenant.name;   // always present
    const tenantId   = credentials.tenant.id;     // Kubernetes CRD UID; null for file-based tenants
    // … authenticate against the tenant-scoped external service …
  }
}
```

- New `JSInputTenant { name, id }` — `id` is the Kubernetes CRD UID when the tenant is loaded from a CRD, `nil` for file-based tenants (identify those by `name`).
- `tenant` added to `JSInputCredentials` and `JSInputUsername`.
- Threaded through all four provider call sites: `LoginController` (interactive login), `ActivateController` (device grant), the password grant, and `UserValidation` (refresh-token re-validation).

The field is **additive** — existing provider scripts that ignore `tenant` keep working unchanged.

## Tests

- `UserLoginTenantContextTest` (new): a provider script reads `credentials.tenant.name`/`.id` and the values are asserted end-to-end; plus `JSInputTenant(from:)` mapping for Kubernetes vs. file tenant refs.
- Updated `JSInputParameterTest` and the other provider tests for the new field (encode/decode/round-trip).

## Verification

- `swift build` clean; provider + controller suites **102/102 pass**; `./tooling.sh lint` **0 violations**.
- Not run: full e2e suite (needs a kind cluster).