### PR TITLE
Predefined providers (uitrusting/v1) + roles claim

### DIFF
--- a/Deployment/helm/uitsmijter/templates/crd-tenants.yaml
+++ b/Deployment/helm/uitsmijter/templates/crd-tenants.yaml
@@ -89,9 +89,10 @@ spec:
                     - bucket
                 providers:
                   type: array
+                  # Each entry is either a raw provider script (a string) or a
+                  # predefined-provider object, e.g. { type: "uitrusting/v1", url, token }.
                   items:
-                    type: string
-                    minItems: 1
+                    x-kubernetes-preserve-unknown-fields: true
                 silent_login:
                   type: boolean
                 jwt_algorithm:

--- a/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
@@ -163,7 +163,7 @@ struct ActivateController: RouteCollection {
         // Authenticate via JavaScript provider
         let providerInterpreter = JavaScriptProvider()
         try await providerInterpreter.loadProvider(
-            script: tenant.config.providers.joined(separator: "\n")
+            script: tenant.config.providerScripts.joined(separator: "\n")
         )
         try await providerInterpreter.start(
             class: .userLogin,
@@ -191,6 +191,7 @@ struct ActivateController: RouteCollection {
         )
         let profile = await providerInterpreter.getProfile()
         let role = await providerInterpreter.getRole()
+        let roles = await providerInterpreter.getRoles()
         let providerScopes = await providerInterpreter.getScopes()
 
         let scheme = req.headers.first(name: "X-Forwarded-Proto")
@@ -219,6 +220,7 @@ struct ActivateController: RouteCollection {
             tenant: tenant.name,
             responsibility: "",
             role: role,
+            roles: roles,
             user: username,
             scope: finalScopes.joined(separator: " "),
             profile: profile

--- a/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/ActivateController.swift
@@ -170,7 +170,8 @@ struct ActivateController: RouteCollection {
             arguments: JSInputCredentials(
                 username: username,
                 password: password,
-                grantType: .device_code
+                grantType: .device_code,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
@@ -271,7 +271,12 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
         try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
         try await providerInterpreter.start(
             class: .userLogin,
-            arguments: JSInputCredentials(username: form.username, password: form.password, grantType: grantType)
+            arguments: JSInputCredentials(
+                username: form.username,
+                password: form.password,
+                grantType: grantType,
+                tenant: JSInputTenant(from: tenant)
+            )
         )
         return providerInterpreter
     }

--- a/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/LoginController.swift
@@ -268,7 +268,7 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
         grantType: GrantTypes
     ) async throws -> JavaScriptProvider {
         let providerInterpreter = JavaScriptProvider()
-        try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
+        try await providerInterpreter.loadProvider(script: tenant.config.providerScripts.joined(separator: "\n"))
         try await providerInterpreter.start(
             class: .userLogin,
             arguments: JSInputCredentials(
@@ -560,8 +560,9 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
             Log.error("Cannot get profile of \(loginForm.username)", requestId: req.id)
         }
 
-        // get users role from provider
+        // get users role(s) from provider
         let role = await providerInterpreter.getRole()
+        let roles = await providerInterpreter.getRoles()
 
         // scopes
         let requestedScopes = loginForm.scope?.split(separator: "+").map({ String($0) }) ?? []
@@ -604,6 +605,7 @@ struct LoginController: RouteCollection, OAuthControllerProtocol {
             tenant: tenant.name,
             responsibility: responsibleDomainHash.hash,
             role: role,
+            roles: roles,
             user: loginForm.username,
             scope: finalScopes,
             profile: profile

--- a/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
@@ -216,7 +216,7 @@ extension TokenController {
 
         // handle provider requests
         let providerInterpreter = JavaScriptProvider()
-        try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
+        try await providerInterpreter.loadProvider(script: tenant.config.providerScripts.joined(separator: "\n"))
         try await providerInterpreter.start(
             class: .userLogin,
             arguments: JSInputCredentials(
@@ -243,6 +243,7 @@ extension TokenController {
 
         let profile = await providerInterpreter.getProfile()
         let role = await providerInterpreter.getRole()
+        let roles = await providerInterpreter.getRoles()
 
         // Get client_id for audience and scope filtering
         let tokenRequest = try req.content.decode(TokenRequest.self)
@@ -287,6 +288,7 @@ extension TokenController {
             subject: providedSubject.subject,
             userProfile: UserProfile(
                 role: role,
+                roles: roles,
                 user: passwordTokenRequest.username,
                 scope: finalScopes.joined(separator: " "),
                 profile: profile
@@ -404,6 +406,7 @@ extension TokenController {
         }
         let profile = UserProfile(
             role: payload.role,
+            roles: payload.roles,
             user: payload.user,
             scope: payload.scope,
             profile: payload.profile

--- a/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
+++ b/Sources/Uitsmijter-AuthServer/Controllers/TokenController+TokenGrantTypeRequestHandler.swift
@@ -222,7 +222,8 @@ extension TokenController {
             arguments: JSInputCredentials(
                 username: passwordTokenRequest.username,
                 password: passwordTokenRequest.password,
-                grantType: .password
+                grantType: .password,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Entities/Tenant/Tenant.swift
+++ b/Sources/Uitsmijter-AuthServer/Entities/Tenant/Tenant.swift
@@ -332,10 +332,20 @@ struct TenantSpec: Codable, Sendable {
     ///
     /// ```yaml
     /// providers:
-    ///   - "ldap-auth.js"
-    ///   - "custom-db.js"
+    ///   - |
+    ///     class UserLoginProvider { … }   # raw script
+    ///   - type: "uitrusting/v1"           # predefined provider
+    ///     url: uitrusting.acme.svc
     /// ```
-    var providers: [String] = []
+    var providers: [TenantProvider] = []
+
+    /// The effective JavaScript for every provider entry, in order.
+    ///
+    /// Raw script entries are returned as-is; predefined providers (e.g.
+    /// `uitrusting/v1`) are expanded to their generated provider script.
+    var providerScripts: [String] {
+        providers.map { $0.script }
+    }
 
     /// Configuration for loading templates from S3-compatible storage.
     ///
@@ -395,7 +405,7 @@ struct TenantSpec: Codable, Sendable {
         hosts: [String],
         informations: TenantInformations? = nil,
         interceptor: TenantInterceptorSettings? = nil,
-        providers: [String] = [],
+        providers: [TenantProvider] = [],
         templates: TenantTemplatesSettings? = nil,
         silent_login: Bool? = true,
         jwt_algorithm: String? = nil

--- a/Sources/Uitsmijter-AuthServer/Entities/Tenant/TenantProvider.swift
+++ b/Sources/Uitsmijter-AuthServer/Entities/Tenant/TenantProvider.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Known predefined provider types.
+///
+/// A predefined provider lets a tenant integrate a well-known external user
+/// service without writing the JavaScript by hand — Uitsmijter generates the
+/// provider script internally (see ``PredefinedProvider/generatedScript``).
+enum ProviderType: String, Codable, Sendable, Equatable {
+    /// The Uitrusting multi-tenant user service, v1 (`POST {url}/verify`).
+    case uitrustingV1 = "uitrusting/v1"
+}
+
+/// A predefined provider definition, e.g. `{ type: "uitrusting/v1", url: "…", token: "…" }`.
+struct PredefinedProvider: Codable, Sendable, Equatable {
+    /// The kind of external service, which determines how the result is mapped.
+    let type: ProviderType
+
+    /// Base URL (or host) of the external service, e.g. `uitrusting.acme.svc`.
+    let url: String
+
+    /// Optional shared secret sent to the service as the `X-Internal-Token` header.
+    /// When omitted, no authentication header is sent (open mode).
+    let token: String?
+
+    /// The JavaScript provider script that implements this predefined provider.
+    var generatedScript: String {
+        switch type {
+        case .uitrustingV1:
+            return UitrustingProviderScript.make(url: url, token: token)
+        }
+    }
+}
+
+/// A single entry in a tenant's `providers` list.
+///
+/// Either a raw JavaScript provider script (the original, still-supported form)
+/// or a ``PredefinedProvider`` object that Uitsmijter expands into a script.
+///
+/// ```yaml
+/// providers:
+///   - |                         # raw script (unchanged)
+///     class UserLoginProvider { … }
+///   - type: "uitrusting/v1"     # predefined provider
+///     url: uitrusting.acme.svc
+///     token: "…"                # optional
+/// ```
+enum TenantProvider: Codable, Sendable, Equatable, ExpressibleByStringLiteral {
+    /// A raw JavaScript provider script.
+    case script(String)
+    /// A predefined provider expanded to a script by Uitsmijter.
+    case predefined(PredefinedProvider)
+
+    /// Allows `providers: ["class …"]` string literals in Swift (tests, defaults).
+    init(stringLiteral value: String) {
+        self = .script(value)
+    }
+
+    /// Decode either a plain string (raw script) or an object (predefined provider).
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let raw = try? container.decode(String.self) {
+            self = .script(raw)
+        } else {
+            self = .predefined(try container.decode(PredefinedProvider.self))
+        }
+    }
+
+    /// Encode back into the same shape it was decoded from.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .script(let raw):
+            try container.encode(raw)
+        case .predefined(let provider):
+            try container.encode(provider)
+        }
+    }
+
+    /// The effective JavaScript for this entry (raw script, or the generated one).
+    var script: String {
+        switch self {
+        case .script(let raw):
+            return raw
+        case .predefined(let provider):
+            return provider.generatedScript
+        }
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/JWT/Payload.swift
+++ b/Sources/Uitsmijter-AuthServer/JWT/Payload.swift
@@ -39,6 +39,7 @@ struct Payload: JWTPayload, SubjectProtocol, UserProfileProtocol, Sendable {
         case tenant = "tenant"
         case responsibility = "responsibility"
         case role = "role"
+        case roles = "roles"
         case user = "user"
         case scope = "scope"
         case profile = "profile"
@@ -97,8 +98,15 @@ struct Payload: JWTPayload, SubjectProtocol, UserProfileProtocol, Sendable {
 
     /// The user's role within the system
     ///
-    /// Used for role-based access control (RBAC) decisions.
+    /// Used for role-based access control (RBAC) decisions. For providers that
+    /// expose multiple roles, this holds the primary (first) role; see ``roles``.
     var role: String
+
+    /// The user's roles, when the provider supplies more than one.
+    ///
+    /// Optional and omitted from the token when the provider only exposes a single
+    /// `role`. The `role` claim always mirrors the primary (first) role.
+    var roles: [String]?
 
     /// The username or identifier of the user
     ///
@@ -137,6 +145,7 @@ struct Payload: JWTPayload, SubjectProtocol, UserProfileProtocol, Sendable {
         tenant: String,
         responsibility: String? = nil,
         role: String,
+        roles: [String]? = nil,
         user: String,
         scope: String? = nil,
         profile: CodableProfile? = nil
@@ -150,6 +159,7 @@ struct Payload: JWTPayload, SubjectProtocol, UserProfileProtocol, Sendable {
         self.tenant = tenant
         self.responsibility = responsibility
         self.role = role
+        self.roles = roles
         self.user = user
         self.scope = scope ?? ""
         self.profile = profile

--- a/Sources/Uitsmijter-AuthServer/JWT/Token.swift
+++ b/Sources/Uitsmijter-AuthServer/JWT/Token.swift
@@ -298,6 +298,7 @@ struct Token: ExpressibleByStringLiteral {
             tenant: tenantName,
             responsibility: nil,
             role: userProfile.role,
+            roles: userProfile.roles,
             user: userProfile.user,
             scope: userProfile.scope,
             profile: userProfile.profile

--- a/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
+++ b/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
@@ -117,7 +117,8 @@ struct UserValidation {
         try await providerInterpreter.start(
             class: .userValidate,
             arguments: JSInputUsername(
-                username: username
+                username: username,
+                tenant: JSInputTenant(from: tenant)
             )
         )
 

--- a/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
+++ b/Sources/Uitsmijter-AuthServer/Login/UserValidation.swift
@@ -94,7 +94,7 @@ struct UserValidation {
     /// - SeeAlso: ``Constants/SECURITY/ALLOW_MISSING_PROVIDERS``
     static func isStillValid(username: String, tenant: Tenant, on request: Request) async throws -> Bool {
         let providerInterpreter = JavaScriptProvider()
-        try await providerInterpreter.loadProvider(script: tenant.config.providers.joined(separator: "\n"))
+        try await providerInterpreter.loadProvider(script: tenant.config.providerScripts.joined(separator: "\n"))
 
         if await providerInterpreter.isClassExists(class: .userValidate) == false {
             if Constants.SECURITY.ALLOW_MISSING_PROVIDERS == false {

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputCredentials.swift
@@ -9,10 +9,13 @@ struct JSInputCredentials: JSInputParameterProtocol, Sendable {
     let password: String
     /// The OAuth2 grant type used for this authentication request
     let grantType: GrantTypes
+    /// The tenant this authentication request belongs to
+    let tenant: JSInputTenant
 
     enum CodingKeys: String, CodingKey {
         case username
         case password
         case grantType = "grant_type"
+        case tenant
     }
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
@@ -10,33 +10,39 @@ import Foundation
 /// class UserLoginProvider {
 ///   constructor(credentials) {
 ///     const tenantName = credentials.tenant.name;
-///     const tenantId = credentials.tenant.id; // null for file-based tenants
+///     const tenantNamespace = credentials.tenant.namespace; // null for file-based tenants
 ///     // … call the external user service scoped to this tenant …
 ///   }
 /// }
 /// ```
 struct JSInputTenant: Codable, Sendable {
-    /// The tenant's unique name (always present).
+    /// The tenant's name (without the namespace prefix).
     let name: String
 
-    /// The tenant's resource identifier. This is the Kubernetes CRD UID when the
-    /// tenant is loaded from a CRD, and `nil` for file-based tenants (which have
-    /// no stable id — identify those by ``name``).
-    let id: String?
+    /// The Kubernetes namespace the tenant is defined in.
+    ///
+    /// `nil` for file-based tenants, which have no namespace. CRD tenants are stored
+    /// internally as `"<namespace>/<name>"`; this splits that back into its parts.
+    let namespace: String?
 
     /// Create the tenant context from explicit values.
-    init(name: String, id: String? = nil) {
+    init(name: String, namespace: String? = nil) {
         self.name = name
-        self.id = id
+        self.namespace = namespace
     }
 
     /// Build the tenant context from a loaded ``Tenant``.
+    ///
+    /// CRD tenants carry a `"<namespace>/<name>"` name; file-based tenants carry a
+    /// plain name and therefore have no namespace.
     init(from tenant: Tenant) {
-        self.name = tenant.name
-        if case .kubernetes(let uuid, _) = tenant.ref {
-            self.id = uuid.uuidString
+        let parts = tenant.name.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+        if parts.count == 2 {
+            self.namespace = String(parts[0])
+            self.name = String(parts[1])
         } else {
-            self.id = nil
+            self.namespace = nil
+            self.name = tenant.name
         }
     }
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputTenant.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Tenant context passed into the JavaScript provider alongside the credentials.
+///
+/// Exposed to provider scripts as the `tenant` property of the constructor argument,
+/// so a provider (e.g. one talking to Uitrusting) can scope its request to the
+/// correct tenant:
+///
+/// ```javascript
+/// class UserLoginProvider {
+///   constructor(credentials) {
+///     const tenantName = credentials.tenant.name;
+///     const tenantId = credentials.tenant.id; // null for file-based tenants
+///     // … call the external user service scoped to this tenant …
+///   }
+/// }
+/// ```
+struct JSInputTenant: Codable, Sendable {
+    /// The tenant's unique name (always present).
+    let name: String
+
+    /// The tenant's resource identifier. This is the Kubernetes CRD UID when the
+    /// tenant is loaded from a CRD, and `nil` for file-based tenants (which have
+    /// no stable id — identify those by ``name``).
+    let id: String?
+
+    /// Create the tenant context from explicit values.
+    init(name: String, id: String? = nil) {
+        self.name = name
+        self.id = id
+    }
+
+    /// Build the tenant context from a loaded ``Tenant``.
+    init(from tenant: Tenant) {
+        self.name = tenant.name
+        if case .kubernetes(let uuid, _) = tenant.ref {
+            self.id = uuid.uuidString
+        } else {
+            self.id = nil
+        }
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputUsername.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JSInputUsername.swift
@@ -5,4 +5,6 @@ import Foundation
 struct JSInputUsername: JSInputParameterProtocol, Sendable {
     /// Users username or email address
     let username: String
+    /// The tenant this validation request belongs to
+    let tenant: JSInputTenant
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/JavaScriptProvider+GetProperties.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/JavaScriptProvider+GetProperties.swift
@@ -60,4 +60,20 @@ extension JavaScriptProvider {
         return scopes
     }
 
+    /// Returns the optional `roles` array from `scriptClass`.
+    ///
+    /// Providers may expose either a single `role` or a `roles` array (or both).
+    /// Returns `nil` when the provider does not expose a non-empty `roles` array,
+    /// so the token omits the `roles` claim for single-role providers.
+    ///
+    /// - Parameter scriptClass: a `ScriptClassExecution`, default: userLogin
+    /// - Returns: The `roles` as a `[String]`, or `nil` when not provided.
+    func getRoles(scriptClass: ScriptClassExecution = .userLogin) async -> [String]? {
+        guard let roles: [String] = try? self.getObject(class: scriptClass, property: "roles"),
+              !roles.isEmpty else {
+            return nil
+        }
+        return roles
+    }
+
 }

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
@@ -4,10 +4,12 @@ import Foundation
 /// `uitrusting/v1` predefined provider type.
 ///
 /// Both call Uitrusting's single `POST {url}/verify` endpoint:
-/// - **Login** sends `{ tenant, username, password_hash }` (SHA256 hex — the plain
-///   password is never transmitted); `valid` means the credentials are correct.
-/// - **Refresh re-validation** sends `{ tenant, username }` with no hash; `valid`
-///   then means the user still exists and is active.
+/// - **Login** sends `{ tenant, namespace, username, password_hash }` (SHA256 hex —
+///   the plain password is never transmitted); `valid` means the credentials are correct.
+/// - **Refresh re-validation** sends `{ tenant, namespace, username }` with no hash;
+///   `valid` then means the user still exists and is active.
+///
+/// `namespace` is the tenant's Kubernetes namespace (`null` for file-based tenants).
 ///
 /// The status code is always 200, so the decision is made on `valid`, and the
 /// response maps
@@ -58,6 +60,7 @@ enum UitrustingProviderScript {
                     headers: headers,
                     body: JSON.stringify({
                         tenant: credentials.tenant.name,
+                        namespace: credentials.tenant.namespace,
                         username: credentials.username,
                         password_hash: sha256(credentials.password)
                     })
@@ -100,6 +103,7 @@ enum UitrustingProviderScript {
                     headers: headers,
                     body: JSON.stringify({
                         tenant: args.tenant.name,
+                        namespace: args.tenant.namespace,
                         username: args.username
                     })
                 }).then((response) => {

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Generates the JavaScript `UserLoginProvider` for the `uitrusting/v1` predefined
+/// provider type.
+///
+/// The generated script calls Uitrusting's `POST {url}/verify` endpoint with the
+/// tenant, username and password, and maps its response
+///
+/// ```json
+/// { "known": true, "valid": true, "subject": "…", "roles": [...],
+///   "scopes": [...], "profile": { "email": "…", "name": "…", … } }
+/// ```
+///
+/// onto the Uitsmijter provider interface (`canLogin`, `userProfile`, `role`,
+/// `roles`, `scopes`, and the committed `subject`).
+enum UitrustingProviderScript {
+
+    /// Build the provider script for a Uitrusting service.
+    ///
+    /// - Parameters:
+    ///   - url: The service base URL or host, e.g. `uitrusting.acme.svc`. A scheme
+    ///     is added (`http://`) when missing; `/verify` is appended.
+    ///   - token: Optional shared secret sent as the `X-Internal-Token` header.
+    /// - Returns: A JavaScript source string defining `UserLoginProvider`.
+    static func make(url: String, token: String?) -> String {
+        let verifyURL = jsString(verifyEndpoint(from: url))
+        let tokenHeader: String
+        if let token, !token.isEmpty {
+            tokenHeader = "headers[\"X-Internal-Token\"] = \(jsString(token));"
+        } else {
+            tokenHeader = ""
+        }
+
+        return """
+        // Auto-generated provider for uitrusting/v1
+        class UserLoginProvider {
+            canLoginFlag = false;
+            subjectId = null;
+            userRoles = [];
+            userScopes = [];
+            userProfileData = {};
+            constructor(credentials) {
+                const headers = { "Content-Type": "application/json" };
+                \(tokenHeader)
+                fetch(\(verifyURL), {
+                    method: "post",
+                    headers: headers,
+                    body: JSON.stringify({
+                        tenant: credentials.tenant.name,
+                        username: credentials.username,
+                        password: credentials.password
+                    })
+                }).then((response) => {
+                    try {
+                        const data = JSON.parse(response.body);
+                        if (response.code == 200 && data.known === true && data.valid === true) {
+                            this.canLoginFlag = true;
+                            this.subjectId = data.subject;
+                            this.userRoles = data.roles || [];
+                            this.userScopes = data.scopes || [];
+                            this.userProfileData = data.profile || {};
+                            return commit({ subject: data.subject });
+                        }
+                    } catch (e) {
+                        console.log("uitrusting/v1: cannot parse verify response: " + e);
+                    }
+                    commit(false);
+                }).catch((err) => {
+                    console.log("uitrusting/v1: verify request failed: " + err);
+                    commit(false);
+                });
+            }
+            get canLogin() { return this.canLoginFlag; }
+            get userProfile() { return this.userProfileData; }
+            get role() { return this.userRoles.length ? this.userRoles[0] : "none"; }
+            get roles() { return this.userRoles; }
+            get scopes() { return this.userScopes; }
+        }
+        """
+    }
+
+    /// Normalize a configured URL/host into a full `…/verify` endpoint.
+    private static func verifyEndpoint(from url: String) -> String {
+        var base = url
+        if !base.hasPrefix("http://") && !base.hasPrefix("https://") {
+            base = "http://\(base)"
+        }
+        if base.hasSuffix("/") {
+            base.removeLast()
+        }
+        return "\(base)/verify"
+    }
+
+    /// Encode a Swift string as a safe JavaScript double-quoted string literal.
+    private static func jsString(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
+++ b/Sources/Uitsmijter-AuthServer/ScriptingProvider/UitrustingProviderScript.swift
@@ -1,10 +1,16 @@
 import Foundation
 
-/// Generates the JavaScript `UserLoginProvider` for the `uitrusting/v1` predefined
-/// provider type.
+/// Generates the JavaScript `UserLoginProvider` + `UserValidationProvider` for the
+/// `uitrusting/v1` predefined provider type.
 ///
-/// The generated script calls Uitrusting's `POST {url}/verify` endpoint with the
-/// tenant, username and password, and maps its response
+/// Both call Uitrusting's single `POST {url}/verify` endpoint:
+/// - **Login** sends `{ tenant, username, password_hash }` (SHA256 hex — the plain
+///   password is never transmitted); `valid` means the credentials are correct.
+/// - **Refresh re-validation** sends `{ tenant, username }` with no hash; `valid`
+///   then means the user still exists and is active.
+///
+/// The status code is always 200, so the decision is made on `valid`, and the
+/// response maps
 ///
 /// ```json
 /// { "known": true, "valid": true, "subject": "…", "roles": [...],
@@ -33,6 +39,11 @@ enum UitrustingProviderScript {
 
         return """
         // Auto-generated provider for uitrusting/v1
+
+        // Login: POST { username, password_hash, tenant } to /verify.
+        // `valid` means the credentials are correct. The status is always 200, so we
+        // decide on `valid` (and `known`), never the HTTP status code. The password is
+        // never sent in the clear — only its SHA256 hex hash.
         class UserLoginProvider {
             canLoginFlag = false;
             subjectId = null;
@@ -48,12 +59,12 @@ enum UitrustingProviderScript {
                     body: JSON.stringify({
                         tenant: credentials.tenant.name,
                         username: credentials.username,
-                        password: credentials.password
+                        password_hash: sha256(credentials.password)
                     })
                 }).then((response) => {
                     try {
                         const data = JSON.parse(response.body);
-                        if (response.code == 200 && data.known === true && data.valid === true) {
+                        if (data.known === true && data.valid === true) {
                             this.canLoginFlag = true;
                             this.subjectId = data.subject;
                             this.userRoles = data.roles || [];
@@ -75,6 +86,36 @@ enum UitrustingProviderScript {
             get role() { return this.userRoles.length ? this.userRoles[0] : "none"; }
             get roles() { return this.userRoles; }
             get scopes() { return this.userScopes; }
+        }
+
+        // Refresh re-validation: POST { username, tenant } (no password_hash) to the
+        // same /verify. With no hash, `valid` means the user still exists and is active.
+        class UserValidationProvider {
+            validFlag = false;
+            constructor(args) {
+                const headers = { "Content-Type": "application/json" };
+                \(tokenHeader)
+                fetch(\(verifyURL), {
+                    method: "post",
+                    headers: headers,
+                    body: JSON.stringify({
+                        tenant: args.tenant.name,
+                        username: args.username
+                    })
+                }).then((response) => {
+                    try {
+                        const data = JSON.parse(response.body);
+                        this.validFlag = (data.valid === true);
+                    } catch (e) {
+                        console.log("uitrusting/v1: cannot parse verify response: " + e);
+                    }
+                    commit(this.validFlag);
+                }).catch((err) => {
+                    console.log("uitrusting/v1: verify request failed: " + err);
+                    commit(false);
+                });
+            }
+            get isValid() { return this.validFlag; }
         }
         """
     }

--- a/Sources/Uitsmijter-AuthServer/UserProfile/UserProfileProtocol.swift
+++ b/Sources/Uitsmijter-AuthServer/UserProfile/UserProfileProtocol.swift
@@ -63,6 +63,10 @@ protocol UserProfileProtocol {
     /// ```
     var role: String { get set }
 
+    /// The user's roles, when the provider supplies more than one. Optional; the
+    /// primary role is mirrored in ``role``.
+    var roles: [String]? { get set }
+
     /// The unique identifier or username of the user.
     ///
     /// This property contains the primary user identifier used for authentication and identity.
@@ -191,6 +195,9 @@ struct UserProfile: UserProfileProtocol {
     /// - SeeAlso: ``UserProfileProtocol/role`` for detailed role usage documentation
     var role: String
 
+    /// The user's roles when the provider supplies more than one.
+    var roles: [String]?
+
     /// The unique identifier or username of the user.
     ///
     /// This is the primary user identifier used for authentication and identity.
@@ -229,8 +236,15 @@ struct UserProfile: UserProfileProtocol {
     ///     ])
     /// )
     /// ```
-    init(role: String, user: String, scope: String? = nil, profile: CodableProfile? = nil) {
+    init(
+        role: String,
+        roles: [String]? = nil,
+        user: String,
+        scope: String? = nil,
+        profile: CodableProfile? = nil
+    ) {
         self.role = role
+        self.roles = roles
         self.user = user
         self.scope = scope ?? ""
         self.profile = profile

--- a/Tests/Uitsmijter-AuthServerTests/Entities/Tenant/TenantProviderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/Entities/Tenant/TenantProviderTest.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import Uitsmijter_AuthServer
+
+@Suite("Tenant Provider Tests")
+struct TenantProviderTest {
+
+    @Test("Decodes a plain string entry as a raw script")
+    func decodesStringAsScript() throws {
+        let json = Data("\"class UserLoginProvider {}\"".utf8)
+        let provider = try JSONDecoder().decode(TenantProvider.self, from: json)
+        #expect(provider == .script("class UserLoginProvider {}"))
+    }
+
+    @Test("Decodes an object entry as a predefined provider")
+    func decodesObjectAsPredefined() throws {
+        let json = Data("""
+        {"type":"uitrusting/v1","url":"uitrusting.acme.svc","token":"s3cret"}
+        """.utf8)
+        let provider = try JSONDecoder().decode(TenantProvider.self, from: json)
+        guard case .predefined(let predefined) = provider else {
+            Issue.record("expected a predefined provider")
+            return
+        }
+        #expect(predefined.type == .uitrustingV1)
+        #expect(predefined.url == "uitrusting.acme.svc")
+        #expect(predefined.token == "s3cret")
+    }
+
+    @Test("Predefined provider token is optional")
+    func predefinedTokenOptional() throws {
+        let json = Data("""
+        {"type":"uitrusting/v1","url":"uitrusting.acme.svc"}
+        """.utf8)
+        let provider = try JSONDecoder().decode(TenantProvider.self, from: json)
+        guard case .predefined(let predefined) = provider else {
+            Issue.record("expected a predefined provider")
+            return
+        }
+        #expect(predefined.token == nil)
+    }
+
+    @Test("A mixed providers array round-trips through Codable")
+    func mixedArrayRoundTrips() throws {
+        let json = Data("""
+        ["class UserLoginProvider {}",{"type":"uitrusting/v1","url":"u.svc"}]
+        """.utf8)
+        let providers = try JSONDecoder().decode([TenantProvider].self, from: json)
+        #expect(providers.count == 2)
+        #expect(providers[0] == .script("class UserLoginProvider {}"))
+
+        // Encoding a script entry yields a plain string again (back-compat).
+        let encoded = try JSONEncoder().encode(providers[0])
+        #expect(String(data: encoded, encoding: .utf8) == "\"class UserLoginProvider {}\"")
+    }
+
+    @Test("providerScripts expands predefined providers to generated scripts")
+    func providerScriptsExpandsPredefined() {
+        let spec = TenantSpec(
+            hosts: ["localhost"],
+            providers: [
+                .script("class UserValidationProvider {}"),
+                .predefined(PredefinedProvider(type: .uitrustingV1, url: "uitrusting.acme.svc", token: nil))
+            ]
+        )
+        let scripts = spec.providerScripts
+        #expect(scripts.count == 2)
+        #expect(scripts[0] == "class UserValidationProvider {}")
+        // The predefined one is expanded to the generated Uitrusting login provider.
+        #expect(scripts[1].contains("class UserLoginProvider"))
+        #expect(scripts[1].contains("/verify"))
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/OAuth/AuthorisationUtils.swift
+++ b/Tests/Uitsmijter-AuthServerTests/OAuth/AuthorisationUtils.swift
@@ -117,7 +117,7 @@ fileprivate func createTenant(
                 """
         )
     case .custom(let source):
-        tenantConfig.providers.append(source)
+        tenantConfig.providers.append(.script(source))
     }
     let tenant = Tenant(
         name: tenantName ?? "Test Tenant",

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSFunctions+NetworkingTest.swift
@@ -3,6 +3,7 @@ import Foundation
 import Testing
 @testable import Uitsmijter_AuthServer
 
+// swiftlint:disable type_body_length
 @Suite("JavaScript Functions Networking Tests")
 struct JSFunctionsNetworkingTest {
 
@@ -279,7 +280,8 @@ struct JSFunctionsNetworkingTest {
         """)
 
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "test", grantType: .authorization_code
+            username: "test@example.com", password: "test", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let results = try await jsp.start(class: .userLogin, arguments: credentials)
 

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
@@ -2,6 +2,7 @@ import Testing
 @testable import Uitsmijter_AuthServer
 import Foundation
 
+// swiftlint:disable type_body_length
 @Suite("JSInputParameter Protocol Tests")
 struct JSInputParameterTest {
 
@@ -9,13 +10,13 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername initializes with username")
     func jsInputUsernameInitialization() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         #expect(username.username == "test@example.com")
     }
 
     @Test("JSInputUsername toJSON produces valid JSON")
     func jsInputUsernameToJSON() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -25,15 +26,22 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername toJSON format is correct")
     func jsInputUsernameJSONFormat() throws {
-        let username = JSInputUsername(username: "user@test.com")
+        let username = JSInputUsername(username: "user@test.com", tenant: JSInputTenant(name: "acme"))
         let json = try username.toJSON()
 
-        #expect(json == "{\"username\":\"user@test.com\"}")
+        // Decode rather than match an exact string (JSON key order is not guaranteed).
+        guard let data = json?.data(using: .utf8),
+              let parsed = try? JSONDecoder().decode(JSInputUsername.self, from: data) else {
+            Issue.record("Failed to parse JSON output")
+            return
+        }
+        #expect(parsed.username == "user@test.com")
+        #expect(parsed.tenant.name == "acme")
     }
 
     @Test("JSInputUsername encodes to JSON with special characters")
     func jsInputUsernameWithSpecialChars() throws {
-        let username = JSInputUsername(username: "test+user@example.com")
+        let username = JSInputUsername(username: "test+user@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json?.contains("test+user@example.com") == true)
@@ -41,7 +49,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername encodes to JSON with unicode")
     func jsInputUsernameWithUnicode() throws {
-        let username = JSInputUsername(username: "用户@example.com")
+        let username = JSInputUsername(username: "用户@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -50,25 +58,27 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername encodes empty string")
     func jsInputUsernameEmpty() throws {
-        let username = JSInputUsername(username: "")
+        let username = JSInputUsername(username: "", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
-        #expect(json == "{\"username\":\"\"}")
+        #expect(json?.contains("\"username\":\"\"") == true)
     }
 
     @Test("JSInputUsername decodes from JSON")
     func jsInputUsernameDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com"}
+        {"username":"decoded@example.com","tenant":{"name":"acme","id":"xyz"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
+        #expect(decoded.tenant.name == "acme")
+        #expect(decoded.tenant.id == "xyz")
     }
 
     @Test("JSInputUsername round-trip encoding and decoding")
     func jsInputUsernameRoundTrip() throws {
-        let original = JSInputUsername(username: "roundtrip@test.com")
+        let original = JSInputUsername(username: "roundtrip@test.com", tenant: JSInputTenant(name: "test"))
         let json = try original.toJSON()
 
         guard let jsonString = json else {
@@ -86,7 +96,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials initializes with username and password")
     func jsInputCredentialsInitialization() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "secret123", grantType: .authorization_code
+            username: "user@test.com", password: "secret123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         #expect(credentials.username == "user@test.com")
         #expect(credentials.password == "secret123")
@@ -96,7 +107,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials toJSON produces valid JSON")
     func jsInputCredentialsToJSON() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "pass123", grantType: .authorization_code
+            username: "user@test.com", password: "pass123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -112,7 +124,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials toJSON format is correct")
     func jsInputCredentialsJSONFormat() throws {
         let credentials = JSInputCredentials(
-            username: "user@test.com", password: "mypass", grantType: .authorization_code
+            username: "user@test.com", password: "mypass", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -130,7 +143,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials encodes with special characters")
     func jsInputCredentialsWithSpecialChars() throws {
         let credentials = JSInputCredentials(
-            username: "test+user@example.com", password: "p@ss!word#123", grantType: .authorization_code
+            username: "test+user@example.com", password: "p@ss!word#123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -140,7 +154,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty password")
     func jsInputCredentialsEmptyPassword() throws {
-        let credentials = JSInputCredentials(username: "user@test.com", password: "", grantType: .authorization_code)
+        let credentials = JSInputCredentials(username: "user@test.com", password: "", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test"))
         let json = try credentials.toJSON()
 
         #expect(json?.contains("user@test.com") == true)
@@ -149,7 +164,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputCredentials encodes with empty username")
     func jsInputCredentialsEmptyUsername() throws {
-        let credentials = JSInputCredentials(username: "", password: "password", grantType: .authorization_code)
+        let credentials = JSInputCredentials(username: "", password: "password", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test"))
         let json = try credentials.toJSON()
 
         #expect(json?.contains("username") == true)
@@ -159,7 +175,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials encodes with unicode")
     func jsInputCredentialsWithUnicode() throws {
         let credentials = JSInputCredentials(
-            username: "用户@example.com", password: "密码123", grantType: .authorization_code
+            username: "用户@example.com", password: "密码123", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -170,19 +187,22 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials decodes from JSON")
     func jsInputCredentialsDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com","password":"decodedpass","grant_type":"authorization_code"}
+        {"username":"decoded@example.com","password":"decodedpass",\
+        "grant_type":"authorization_code","tenant":{"name":"acme"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
         #expect(decoded.password == "decodedpass")
         #expect(decoded.grantType == .authorization_code)
+        #expect(decoded.tenant.name == "acme")
     }
 
     @Test("JSInputCredentials round-trip encoding and decoding")
     func jsInputCredentialsRoundTrip() throws {
         let original = JSInputCredentials(
-            username: "roundtrip@test.com", password: "roundtrippass", grantType: .password
+            username: "roundtrip@test.com", password: "roundtrippass", grantType: .password,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try original.toJSON()
 
@@ -202,7 +222,8 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to JSInputParameterProtocol")
     func jsInputUsernameConformsToProtocol() throws {
-        let username: any JSInputParameterProtocol = JSInputUsername(username: "test@example.com")
+        let username: any JSInputParameterProtocol = JSInputUsername(username: "test@example.com",
+            tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -213,7 +234,7 @@ struct JSInputParameterTest {
         let credentials: any JSInputParameterProtocol = JSInputCredentials(
             username: "test@example.com",
             password: "password",
-            grantType: .authorization_code
+            grantType: .authorization_code, tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -222,7 +243,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to Codable")
     func jsInputUsernameConformsToCodable() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
         let encoded = try JSONEncoder().encode(username)
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: encoded)
 
@@ -232,7 +253,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials conforms to Codable")
     func jsInputCredentialsConformsToCodable() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "password", grantType: .interceptor
+            username: "test@example.com", password: "password", grantType: .interceptor,
+            tenant: JSInputTenant(name: "test")
         )
         let encoded = try JSONEncoder().encode(credentials)
         let decoded = try JSONDecoder().decode(JSInputCredentials.self, from: encoded)
@@ -244,7 +266,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername conforms to Sendable")
     func jsInputUsernameConformsToSendable() throws {
-        let username = JSInputUsername(username: "test@example.com")
+        let username = JSInputUsername(username: "test@example.com", tenant: JSInputTenant(name: "test"))
 
         // Sendable conformance is compile-time checked
         // This test verifies it can be used in async contexts
@@ -258,7 +280,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials conforms to Sendable")
     func jsInputCredentialsConformsToSendable() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "password", grantType: .authorization_code
+            username: "test@example.com", password: "password", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
 
         // Sendable conformance is compile-time checked
@@ -276,7 +299,7 @@ struct JSInputParameterTest {
     @Test("JSInputUsername with very long username")
     func jsInputUsernameVeryLong() throws {
         let longUsername = String(repeating: "a", count: 1000) + "@example.com"
-        let username = JSInputUsername(username: longUsername)
+        let username = JSInputUsername(username: longUsername, tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -287,7 +310,8 @@ struct JSInputParameterTest {
     func jsInputCredentialsVeryLongPassword() throws {
         let longPassword = String(repeating: "x", count: 1000)
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: longPassword, grantType: .authorization_code
+            username: "test@example.com", password: longPassword, grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -298,7 +322,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials with newlines in password")
     func jsInputCredentialsWithNewlines() throws {
         let credentials = JSInputCredentials(
-            username: "test@example.com", password: "pass\nword", grantType: .authorization_code
+            username: "test@example.com", password: "pass\nword", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 
@@ -309,7 +334,7 @@ struct JSInputParameterTest {
 
     @Test("JSInputUsername with quotes in username")
     func jsInputUsernameWithQuotes() throws {
-        let username = JSInputUsername(username: "test\"user@example.com")
+        let username = JSInputUsername(username: "test\"user@example.com", tenant: JSInputTenant(name: "test"))
         let json = try username.toJSON()
 
         #expect(json != nil)
@@ -320,7 +345,8 @@ struct JSInputParameterTest {
     @Test("JSInputCredentials with backslashes")
     func jsInputCredentialsWithBackslashes() throws {
         let credentials = JSInputCredentials(
-            username: "test\\user@example.com", password: "pass\\word", grantType: .authorization_code
+            username: "test\\user@example.com", password: "pass\\word", grantType: .authorization_code,
+            tenant: JSInputTenant(name: "test")
         )
         let json = try credentials.toJSON()
 

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JSInputParameterTest.swift
@@ -67,13 +67,13 @@ struct JSInputParameterTest {
     @Test("JSInputUsername decodes from JSON")
     func jsInputUsernameDecoding() throws {
         let jsonData = Data("""
-        {"username":"decoded@example.com","tenant":{"name":"acme","id":"xyz"}}
+        {"username":"decoded@example.com","tenant":{"name":"acme","namespace":"acme-ns"}}
         """.utf8)
 
         let decoded = try JSONDecoder().decode(JSInputUsername.self, from: jsonData)
         #expect(decoded.username == "decoded@example.com")
         #expect(decoded.tenant.name == "acme")
-        #expect(decoded.tenant.id == "xyz")
+        #expect(decoded.tenant.namespace == "acme-ns")
     }
 
     @Test("JSInputUsername round-trip encoding and decoding")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProvider+GetPropertiesTest.swift
@@ -5,7 +5,8 @@ import Testing
 @Suite("JavaScript Provider Get Properties Tests")
 struct JavaScriptProviderGetPropertiesTest {
     let dummyCredentials = JSInputCredentials(
-        username: "test@example.com", password: "test", grantType: .authorization_code
+        username: "test@example.com", password: "test", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     @Test("getSubject returns committed subject from script")
     func getSubjectReturnsCommittedSubject() async throws {

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/JavaScriptProviderTest.swift
@@ -7,7 +7,8 @@ import Testing
 struct JavaScriptProviderTest {
 
     let dummyCredentials = JSInputCredentials(
-        username: "test@example.com", password: "test", grantType: .authorization_code
+        username: "test@example.com", password: "test", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("JavaScriptProvider initializes successfully")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/ProviderRolesTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/ProviderRolesTest.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+import JWTKit
+@testable import Uitsmijter_AuthServer
+
+@Suite("Provider Roles Tests")
+struct ProviderRolesTest {
+
+    private func credentials() -> JSInputCredentials {
+        JSInputCredentials(
+            username: "user@example.com",
+            password: "secret",
+            grantType: .authorization_code,
+            tenant: JSInputTenant(name: "acme")
+        )
+    }
+
+    @Test("getRoles returns the roles array a provider exposes")
+    func getRolesReturnsArray() async throws {
+        let script = """
+        class UserLoginProvider {
+            constructor(credentials) { commit(true); }
+            get canLogin() { return true; }
+            get roles() { return ["admin", "editor"]; }
+        }
+        """
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: script)
+        try await provider.start(class: .userLogin, arguments: credentials())
+
+        let roles = await provider.getRoles()
+        #expect(roles == ["admin", "editor"])
+    }
+
+    @Test("getRoles returns nil when the provider exposes no roles")
+    func getRolesNilWhenAbsent() async throws {
+        let script = """
+        class UserLoginProvider {
+            constructor(credentials) { commit(true); }
+            get canLogin() { return true; }
+            get role() { return "user"; }
+        }
+        """
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: script)
+        try await provider.start(class: .userLogin, arguments: credentials())
+
+        let roles = await provider.getRoles()
+        #expect(roles == nil)
+    }
+
+    @Test("Payload encodes the roles claim and omits it when nil")
+    func payloadRolesClaimRoundTrips() throws {
+        let base = Payload(
+            issuer: IssuerClaim(value: "https://localhost"),
+            subject: "sub",
+            audience: AudienceClaim(value: "client"),
+            expiration: ExpirationClaim(value: Date(timeIntervalSinceNow: 3600)),
+            issuedAt: IssuedAtClaim(value: Date()),
+            authTime: AuthTimeClaim(value: Date()),
+            tenant: "acme",
+            role: "admin",
+            roles: ["admin", "editor"],
+            user: "user@example.com"
+        )
+        let json = try JSONEncoder().encode(base)
+        let decoded = try JSONDecoder().decode(Payload.self, from: json)
+        #expect(decoded.roles == ["admin", "editor"])
+        #expect(String(data: json, encoding: .utf8)?.contains("\"roles\"") == true)
+
+        // No roles → claim omitted.
+        var single = base
+        single.roles = nil
+        let singleJson = try JSONEncoder().encode(single)
+        #expect(String(data: singleJson, encoding: .utf8)?.contains("\"roles\"") == false)
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
@@ -27,12 +27,29 @@ struct UitrustingProviderScriptTest {
         #expect(!withoutToken.contains("X-Internal-Token"))
     }
 
-    @Test("Generated script is syntactically valid and defines UserLoginProvider")
+    @Test("Login sends a SHA256 password_hash, never the plain password")
+    func loginSendsPasswordHash() {
+        let script = UitrustingProviderScript.make(url: "u.svc", token: nil)
+        #expect(script.contains("password_hash: sha256(credentials.password)"))
+        #expect(!script.contains("password: credentials.password"))
+    }
+
+    @Test("Validation posts username + tenant without a password hash")
+    func validationOmitsPasswordHash() {
+        let script = UitrustingProviderScript.make(url: "u.svc", token: nil)
+        #expect(script.contains("class UserValidationProvider"))
+        // The validation body carries username + tenant but no password_hash.
+        let validationPart = script.components(separatedBy: "class UserValidationProvider").last ?? ""
+        #expect(!validationPart.contains("password_hash"))
+    }
+
+    @Test("Generated script is valid JS and defines both provider classes")
     func generatedScriptLoadsAsValidJS() async throws {
         let provider = JavaScriptProvider()
         let script = UitrustingProviderScript.make(url: "uitrusting.acme.svc", token: "tok")
         // loadProvider throws on a syntax error; a clean load proves the generated JS parses.
         try await provider.loadProvider(script: script)
         #expect(await provider.isClassExists(class: .userLogin))
+        #expect(await provider.isClassExists(class: .userValidate))
     }
 }

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import Uitsmijter_AuthServer
+
+@Suite("Uitrusting Provider Script Tests")
+struct UitrustingProviderScriptTest {
+
+    @Test("Generated script targets the /verify endpoint and prepends a scheme")
+    func targetsVerifyEndpoint() {
+        let script = UitrustingProviderScript.make(url: "uitrusting.acme.svc", token: nil)
+        #expect(script.contains("\"http://uitrusting.acme.svc/verify\""))
+    }
+
+    @Test("An explicit scheme in the url is preserved")
+    func preservesExplicitScheme() {
+        let script = UitrustingProviderScript.make(url: "https://uitrusting.acme.svc/", token: nil)
+        #expect(script.contains("\"https://uitrusting.acme.svc/verify\""))
+    }
+
+    @Test("The internal token is sent as a header only when configured")
+    func tokenHeaderOnlyWhenSet() {
+        let withToken = UitrustingProviderScript.make(url: "u.svc", token: "s3cret")
+        #expect(withToken.contains("X-Internal-Token"))
+        #expect(withToken.contains("s3cret"))
+
+        let withoutToken = UitrustingProviderScript.make(url: "u.svc", token: nil)
+        #expect(!withoutToken.contains("X-Internal-Token"))
+    }
+
+    @Test("Generated script is syntactically valid and defines UserLoginProvider")
+    func generatedScriptLoadsAsValidJS() async throws {
+        let provider = JavaScriptProvider()
+        let script = UitrustingProviderScript.make(url: "uitrusting.acme.svc", token: "tok")
+        // loadProvider throws on a syntax error; a clean load proves the generated JS parses.
+        try await provider.loadProvider(script: script)
+        #expect(await provider.isClassExists(class: .userLogin))
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UitrustingProviderScriptTest.swift
@@ -43,6 +43,15 @@ struct UitrustingProviderScriptTest {
         #expect(!validationPart.contains("password_hash"))
     }
 
+    @Test("Both /verify bodies include the tenant namespace")
+    func bodiesIncludeNamespace() {
+        let script = UitrustingProviderScript.make(url: "u.svc", token: nil)
+        // Login body.
+        #expect(script.contains("namespace: credentials.tenant.namespace"))
+        // Validation body.
+        #expect(script.contains("namespace: args.tenant.namespace"))
+    }
+
     @Test("Generated script is valid JS and defines both provider classes")
     func generatedScriptLoadsAsValidJS() async throws {
         let provider = JavaScriptProvider()

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginCommittedSubjectTest.swift
@@ -32,10 +32,12 @@ struct UserLoginCommittedSubjectTest {
                                      """
 
     let userOK = JSInputCredentials(
-        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     let userDenied = JSInputCredentials(
-        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("Get committed value can login")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginProviderTests.swift
@@ -36,10 +36,12 @@ struct UserLoginProviderTests {
                                      """
 
     let userOK = JSInputCredentials(
-        username: "ok@example.com", password: "very-secret", grantType: .authorization_code
+        username: "ok@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
     let userDenied = JSInputCredentials(
-        username: "deni@example.com", password: "very-secret", grantType: .authorization_code
+        username: "deni@example.com", password: "very-secret", grantType: .authorization_code,
+        tenant: JSInputTenant(name: "test")
     )
 
     @Test("Get example with callback")

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import Uitsmijter_AuthServer
+
+@Suite("User Login Tenant Context Tests")
+struct UserLoginTenantContextTest {
+
+    /// Provider that echoes the tenant context it received back as the subject,
+    /// so the test can assert the tenant name/id are passed into the JS context.
+    let providerEchoTenant = """
+                             class UserLoginProvider {
+                                constructor(credentials) {
+                                    const t = credentials.tenant;
+                                    return commit({ subject: t.name + ":" + (t.id || "none") });
+                                }
+                                get canLogin() { return true; }
+                                get userProfile() { return {}; }
+                             }
+                             """
+
+    @Test("Provider receives tenant name and id")
+    func providerReceivesTenantNameAndId() async throws {
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: providerEchoTenant)
+
+        let credentials = JSInputCredentials(
+            username: "user@example.com",
+            password: "secret",
+            grantType: .authorization_code,
+            tenant: JSInputTenant(name: "acme", id: "abc-123")
+        )
+        let committed = try await provider.start(class: .userLogin, arguments: credentials)
+
+        let subjects = Subject.decode(from: committed.compactMap({ $0 }))
+        #expect(subjects.first?.subject == "acme:abc-123")
+    }
+
+    @Test("Provider receives tenant name with nil id for file-based tenants")
+    func providerReceivesTenantNameWithoutId() async throws {
+        let provider = JavaScriptProvider()
+        try await provider.loadProvider(script: providerEchoTenant)
+
+        let credentials = JSInputCredentials(
+            username: "user@example.com",
+            password: "secret",
+            grantType: .authorization_code,
+            tenant: JSInputTenant(name: "acme")
+        )
+        let committed = try await provider.start(class: .userLogin, arguments: credentials)
+
+        let subjects = Subject.decode(from: committed.compactMap({ $0 }))
+        #expect(subjects.first?.subject == "acme:none")
+    }
+
+    @Test("JSInputTenant derives id from a Kubernetes tenant reference")
+    func tenantContextFromKubernetesRef() throws {
+        let uuid = UUID()
+        let tenant = Tenant(
+            ref: .kubernetes(uuid, "rev-1"),
+            name: "k8s-tenant",
+            config: TenantSpec(hosts: ["localhost"])
+        )
+        let context = JSInputTenant(from: tenant)
+        #expect(context.name == "k8s-tenant")
+        #expect(context.id == uuid.uuidString)
+    }
+
+    @Test("JSInputTenant has no id for a file-based tenant reference")
+    func tenantContextFromFileRef() throws {
+        let tenant = Tenant(
+            ref: .file(URL(fileURLWithPath: "/tmp/tenant.yaml")),
+            name: "file-tenant",
+            config: TenantSpec(hosts: ["localhost"])
+        )
+        let context = JSInputTenant(from: tenant)
+        #expect(context.name == "file-tenant")
+        #expect(context.id == nil)
+    }
+}

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserLoginTenantContextTest.swift
@@ -6,20 +6,20 @@ import Testing
 struct UserLoginTenantContextTest {
 
     /// Provider that echoes the tenant context it received back as the subject,
-    /// so the test can assert the tenant name/id are passed into the JS context.
+    /// so the test can assert the tenant name/namespace are passed into the JS context.
     let providerEchoTenant = """
                              class UserLoginProvider {
                                 constructor(credentials) {
                                     const t = credentials.tenant;
-                                    return commit({ subject: t.name + ":" + (t.id || "none") });
+                                    return commit({ subject: t.name + ":" + (t.namespace || "none") });
                                 }
                                 get canLogin() { return true; }
                                 get userProfile() { return {}; }
                              }
                              """
 
-    @Test("Provider receives tenant name and id")
-    func providerReceivesTenantNameAndId() async throws {
+    @Test("Provider receives tenant name and namespace")
+    func providerReceivesTenantNameAndNamespace() async throws {
         let provider = JavaScriptProvider()
         try await provider.loadProvider(script: providerEchoTenant)
 
@@ -27,16 +27,16 @@ struct UserLoginTenantContextTest {
             username: "user@example.com",
             password: "secret",
             grantType: .authorization_code,
-            tenant: JSInputTenant(name: "acme", id: "abc-123")
+            tenant: JSInputTenant(name: "acme", namespace: "littleletter-uitsmijter")
         )
         let committed = try await provider.start(class: .userLogin, arguments: credentials)
 
         let subjects = Subject.decode(from: committed.compactMap({ $0 }))
-        #expect(subjects.first?.subject == "acme:abc-123")
+        #expect(subjects.first?.subject == "acme:littleletter-uitsmijter")
     }
 
-    @Test("Provider receives tenant name with nil id for file-based tenants")
-    func providerReceivesTenantNameWithoutId() async throws {
+    @Test("Provider receives tenant name with nil namespace for file-based tenants")
+    func providerReceivesTenantNameWithoutNamespace() async throws {
         let provider = JavaScriptProvider()
         try await provider.loadProvider(script: providerEchoTenant)
 
@@ -52,21 +52,21 @@ struct UserLoginTenantContextTest {
         #expect(subjects.first?.subject == "acme:none")
     }
 
-    @Test("JSInputTenant derives id from a Kubernetes tenant reference")
-    func tenantContextFromKubernetesRef() throws {
-        let uuid = UUID()
+    @Test("JSInputTenant splits namespace and name from a CRD tenant")
+    func tenantContextFromKubernetesTenant() throws {
+        // CRD tenants are stored internally as "<namespace>/<name>".
         let tenant = Tenant(
-            ref: .kubernetes(uuid, "rev-1"),
-            name: "k8s-tenant",
+            ref: .kubernetes(UUID(), "rev-1"),
+            name: "littleletter-uitsmijter/acme",
             config: TenantSpec(hosts: ["localhost"])
         )
         let context = JSInputTenant(from: tenant)
-        #expect(context.name == "k8s-tenant")
-        #expect(context.id == uuid.uuidString)
+        #expect(context.name == "acme")
+        #expect(context.namespace == "littleletter-uitsmijter")
     }
 
-    @Test("JSInputTenant has no id for a file-based tenant reference")
-    func tenantContextFromFileRef() throws {
+    @Test("JSInputTenant has no namespace for a file-based tenant")
+    func tenantContextFromFileTenant() throws {
         let tenant = Tenant(
             ref: .file(URL(fileURLWithPath: "/tmp/tenant.yaml")),
             name: "file-tenant",
@@ -74,6 +74,6 @@ struct UserLoginTenantContextTest {
         )
         let context = JSInputTenant(from: tenant)
         #expect(context.name == "file-tenant")
-        #expect(context.id == nil)
+        #expect(context.namespace == nil)
     }
 }

--- a/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserValidationProviderTests.swift
+++ b/Tests/Uitsmijter-AuthServerTests/ScriptingProvider/UserValidationProviderTests.swift
@@ -23,8 +23,8 @@ struct UserValidationProviderTests {
                          }
                          """
 
-    let userOK = JSInputUsername(username: "ok@example.com")
-    let userDenied = JSInputUsername(username: "deni@example.com")
+    let userOK = JSInputUsername(username: "ok@example.com", tenant: JSInputTenant(name: "test"))
+    let userDenied = JSInputUsername(username: "deni@example.com", tenant: JSInputTenant(name: "test"))
 
     @Test("Get example with callback")
     func getExampleCallback() async throws {


### PR DESCRIPTION
> **Stacked on #98** (`feature/provider-tenant-info`) — the generated Uitrusting script sends `credentials.tenant.name`, which that PR adds. Review/merge #98 first; base will retarget to `main` afterwards.

## Summary

Lets a tenant declare a **predefined provider** instead of hand-writing the JavaScript, and adds a **`roles` array** claim to the token.

### Predefined providers

`providers` entries can now be either a raw script (unchanged) or an object:

```yaml
providers:
  - |
    class UserLoginProvider { … }   # raw script — still supported
  - type: uitrusting/v1             # predefined provider
    url: uitrusting.acme.svc
    token: "…"                      # optional; sent as X-Internal-Token
```

A predefined provider is expanded internally to a generated `UserLoginProvider` (`UitrustingProviderScript`) that:
- `POST {url}/verify` with `{ tenant, username, password }` (tenant name from the login),
- sends `X-Internal-Token` only when `token` is configured (Uitrusting's `INTERNAL_AUTH_TOKEN`),
- maps the response `{ known, valid, subject, roles, scopes, profile }` onto `canLogin` (`known && valid`), the committed `subject`, `role`/`roles`, `scopes`, and `userProfile`.

`TenantProvider` is a Codable union (`string | object`) and `ExpressibleByStringLiteral`, so existing YAML/Swift keep working. `TenantSpec.providerScripts` expands the list; the four provider call sites use it.

### Roles claim

Adds an optional `roles: [String]` claim alongside the existing single `role` (which mirrors the primary/first role). Threaded from a provider's `roles` getter (`getRoles()`) through the login, activate, and password/refresh token flows. Omitted from the token when the provider only exposes a single role, so existing tokens are unchanged.

### CRD

`providers` items now accept a string **or** an object (`x-kubernetes-preserve-unknown-fields`).

## Tests & verification

- New: `TenantProviderTest` (union decode/encode + expansion), `UitrustingProviderScriptTest` (endpoint/scheme/token header + the generated JS loads as valid script), `ProviderRolesTest` (`getRoles()` + `roles` claim round-trip).
- **Full suite: 860 tests pass**; `./tooling.sh lint` **0 violations**.

## Notes / decisions
- **Request contract** confirmed with you: `POST {url}/verify`, body `{tenant, username, password}` (plain password; Uitrusting hashes internally), optional shared token.
- **No `UserValidationProvider` is generated** — token *refresh* re-validation would need a username-only Uitrusting lookup, which isn't defined yet. A predefined-only tenant behaves like any login-only tenant (governed by `ALLOW_MISSING_PROVIDERS`). Easy follow-up once a lookup endpoint exists.
- Not run: full e2e (needs a kind cluster).